### PR TITLE
Merge apache-arrow into apache-cpp separate from python:pyarrow

### DIFF
--- a/800.renames-and-merges/a.yaml
+++ b/800.renames-and-merges/a.yaml
@@ -86,8 +86,6 @@
 - { setname: apache,                   name: apache-tools, addflavor: tools }
 - { setname: apache,                   name: htdigest, addflavor: htdigest }
 - { setname: apache,                   namepat: "apache[0-9.]+" }
-- { setname: apache-arrow,             name: "python:pyarrow" }
-- { setname: apache-arrow,             name: apache-arrow-glib, addflavor: glib }
 - { setname: apcupsd,                  name: [apcupsd-x11,apcupsd-cgi] }
 - { setname: appstream-glib,           name: libappstream-glib }
 - { setname: apq,                      name: apq-base } # ravenports
@@ -113,6 +111,8 @@
 - { setname: arpack-ng,                name: [arpack-ng-mpich,arpack-ng-openmpi,libarpack-ng] }
 - { setname: arpack-ng,                name: arpack, verpat: "[34]\\..*" }
 - { setname: arping,                   name: arping2 }
+- { setname: arrow-cpp,                name: apache-arrow }
+- { setname: arrow-cpp,                name: apache-arrow-glib, addflavor: glib }
 - { setname: artefetcher,              namepat: "artefetcher-qt[45]" }
 - { setname: arx-libertatis,           name: arxlibertatis }
 - { setname: asc,                      name: advanced-strategic-command }


### PR DESCRIPTION
Techicaly apache-cpp and pyarrow are two distinct packages even though they are
built from the same tarball (and there is also a java version). apache-cpp is a
dependency of pyarrow. There is also similarly named relevant package
parquet-cpp.