### PR TITLE
fixup zsnes versions

### DIFF
--- a/900.version-fixes/z.yaml
+++ b/900.version-fixes/z.yaml
@@ -16,3 +16,5 @@
 - { name: zpaq,                        verpat: "[0-9]+",                                   ignore: true }
 - { name: zsh-syntax-highlighting,     verpat: "20[0-9]{6}.*",                             ignore: true } # FreeBSD
 - { name: zshdb,                       verpat: "20[0-9]{6}",                               ignore: true } # aosc snapshot
+- { name: zsnes,                       verpat: "(1\\.51)0",                                setver: $1 } # debian seems to have added a zero to end of the version, XXX: problem
+- { name: zsnes,                       ver: "1.51b",                                       devel: true } # experimental development release


### PR DESCRIPTION
* 1.51b is called "Experimental Linux Binaries" http://board.zsnes.com/phpBB3/viewtopic.php?t=11513
* 1.510 all the debian-derived repositories seem to have an extra 0 on the end of the package version string