### PR TITLE
add nix to r wildcard rule

### DIFF
--- a/500.wildcard.yaml
+++ b/500.wildcard.yaml
@@ -96,7 +96,7 @@
 # R
 - { setname: "r:$1", noflag: not_r, namepat: "r-cran-(.*)", ruleset: [ freebsd, debuntu, arch, pclinuxos, mageia ] }
 - { setname: "r:$1", noflag: not_r, namepat: "r-bioc-(.*)", ruleset: [ debuntu ] }
-- { setname: "r:$1", noflag: not_r, namepat: "r-(.*)",      ruleset: [ pkgsrc, fedora, guix, arch, debuntu, rosa, sisyphus, opensuse ] }
+- { setname: "r:$1", noflag: not_r, namepat: "r-(.*)",      ruleset: [ pkgsrc, fedora, guix, arch, debuntu, rosa, sisyphus, opensuse, nix ] }
 
 # ROS
 - { setname: "ros:$0", noflag: not_ros, category: dev-ros,   ruleset: [ gentoo ] }


### PR DESCRIPTION
Nix recently added the R packages set to the package JSON file that Repology downloads; this fixes the names of all those packages.