### PR TITLE
Add kcm-tablet to kcm-wacomtablet rename rule

### DIFF
--- a/800.renames-and-merges/kde.yaml
+++ b/800.renames-and-merges/kde.yaml
@@ -209,4 +209,4 @@
 
 # KDE has a project awry called "wacomtablet", so some distributions add kcm- prefix
 # to the package (KDE Config Module), since it's not obvious that it belongs to KDE
-- { setname: kcm-wacomtablet, name: wacomtablet }
+- { setname: kcm-wacomtablet, name: [wacomtablet, kcm-tablet] }


### PR DESCRIPTION
openSuSE-specific package name: https://build.opensuse.org/package/show/openSUSE:Leap:15.0:Update/kcm_tablet