### PR TITLE
Correct some distros packaging snapshot as as-of-yet unreleased version

### DIFF
--- a/900.version-fixes/r.yaml
+++ b/900.version-fixes/r.yaml
@@ -15,6 +15,8 @@
 - { name: range-v3,                    ver: "1.0.0",                 family: buckaroo,     incorrect: true } # 0.3.6 https://github.com/ericniebler/range-v3/releases
 - { name: range-v3,                                                  family: buckaroo,     untrusted: true }
 - { name: rar,                         verpat: ".*20[0-9]{6}",                             ignore: true }
+- { name: rawstudio,                   ver: "2.1",                   family: [sisyphus,fedora], incorrect: true } # Fedora and ALT Sisphus are packaging devel snapshot as version number not released ustream
+- { name: rawstudio,                                                 family: [sisyphus,fedora], untrusted: true }
 - { name: rblcheck,                    verpat: "20[0-9]{6}",                               snapshot: true }
 - { name: rblcheck,                    ver: "20020316",                                    outdated: true, disposable: true }
 - { name: rbldnsd,                     verpat: ".*20[0-9]{6}.*",                           ignore: true }


### PR DESCRIPTION
I'm not entirely sure I did this right. It wasn't clear to me if I should be using `ruleset:` or `family:` as a filter here. The deal is that there has never (to date) been a 2.1 release of rawstudio. Version 2.0 was tagged stable many many years ago and since then there has only been commits in the repository with no release tagged. Several distros are packaging snapshots of the repository and calling them 2.1, but this is bogus. I'm trying to correct those so it doesn't show the everybody else as being out of date.