### PR TITLE
Fix font:raleway version mess

### DIFF
--- a/800.renames-and-merges/fonts/r.yaml
+++ b/800.renames-and-merges/fonts/r.yaml
@@ -19,10 +19,13 @@
     - raleway
     - raleway-fonts
     - raleway-ttf
-    - ttf-impallari-raleway-dots
     - ttf-impallari-raleway-family
     - ttf-raleway
     - ttf-raleway-ibx
+
+- setname: "fonts:raleway-dots"
+  name:
+    - ttf-impallari-raleway-dots
 
 - setname: "fonts:ricty"
   name:

--- a/900.version-fixes/f.yaml
+++ b/900.version-fixes/f.yaml
@@ -51,7 +51,8 @@
 - { name: "fonts:mikachan",            ver: "9.1.2006.08.09",                              ignore: true } # openSUSE garbage
 - { name: "fonts:oldstandard",         ver: "2.2really",                                   ignore: true } # debian garbage
 - { name: "fonts:quattrocento",        ver: "2.000",                 family: arch,         ignore: true } # webpage says it's 1.1
-- { name: "fonts:raleway",                                                                 noscheme: true }
+- { name: "fonts:raleway",             verpat: ".*20[0-9]{6}",                             snapshot: true } # dated packages are all snapshots, not even all from the same sources
+- { name: "fonts:raleway",             verge: "4.0",                                       devel: true }  # 4.x series is still only an unreleased partial port to Glyphs
 - { name: "fonts:ubuntu",              ver: "1.0",                   family: pclinuxos,    ignore: true } # no such version on the website
 - { name: fonttosfnt,                  ver: "1.0.5",                 family: opensuse,     incorrect: true }
 - { name: fonttosfnt,                                                family: opensuse,     untrusted: true }


### PR DESCRIPTION
This font is a mess because the upstream sources are all over the place.
Each new version seems to show up on a different distribution channel,
usually without a version number or source code, and people have been
just guessing what they are. There are several upstream source
repositories posted by different people that have worked on the family
but they don't even all match each other.

The most coherent clues come from the changelog posted at Google Fonts:

https://github.com/google/fonts/blob/master/ofl/raleway/FONTLOG.txt

There it is clear that some version scheme has been attempted. The
personal sandbox of one of the designers also suggests the version
3.x being the last official release.

https://github.com/impallari/Raleway

There he also has some ongoing development work tagged as 4.x, but as of
yet it is incomplete and considered unreleased.

This tries to straighten the version scheme processing so snapshots are
ignored, devel versions are so tagged, and the 1.x, 2.x and 3.x releases
are actually assumed to be correct.

Note also Raleway Dots is a separate font with a different upstream
release cycle not actually versioned along with Raleway.