### PR TITLE
Merge font packages into appropriate meta packages

### DIFF
--- a/800.renames-and-merges/fonts/l.yaml
+++ b/800.renames-and-merges/fonts/l.yaml
@@ -34,6 +34,12 @@
     - ttf-liberation
     - ttf-liberation-sans-narrow
 
+- setname: "fonts:libertinus"
+  name:
+    - libertinus
+    - libertinus-fonts
+    - otf-libertinus
+
 - setname: "fonts:linex"
   name:
     - fonts-linex

--- a/800.renames-and-merges/fonts/m.yaml
+++ b/800.renames-and-merges/fonts/m.yaml
@@ -77,6 +77,14 @@
     - montecarlo-font
     - montecarlo_fonts
 
+- setname: "fonts:montserrat"
+  name:
+    - fonts-otf-julietaula-montserrat
+    - julietaula-montserrat-fonts
+    - montserrat
+    - otf-montserrat
+    - ttf-montserrat
+
 - setname: "fonts:mplus" # XXX: e.g. debian gas fonts-mplus 062 and xfonts-mplus 2.2.4. What's the difference?
   name:
     - fonts-mplus


### PR DESCRIPTION
I'm not sure about the Amiri related commit in here. This is a two stage problem: first the CTAN / texlive crew have to pickup the latest upstream font, then distros have to package the package. Lumping them together is interesting from a standpoint of seeing how the font is trickling down into distros, but from a packager standpoint it might show an out of date package that is not the maintainer's problem: the CTAN upstream could be at fault.

How have you handled that case before? Should I pull that commit out of this PR?