### PR TITLE
Combine various Gitlab packages that are release-synced

### DIFF
--- a/800.renames-and-merges/g.yaml
+++ b/800.renames-and-merges/g.yaml
@@ -79,6 +79,8 @@
 - { setname: git,                      name: [git-base,git-docs,git-gitk,git-contrib,git-lite,git-gui,git-bashcompletion,gitweb,git-minimal,git-with-svn], addflavor: true }
 - { setname: git-review,               name: "python:git-review" }
 - { setname: git-review,               name: git-reveiw } # XXX: CREATE PROBLEM
+- { setname: gitlab,                   name: [gitlab-ce, gitlab-ee, gitlab-common], addflavor: true }
+- { setname: gitlab-runner,            name: [gitlab-runner-images, gitlab-ci-multi-runner, gitlab-ci-multi-runner-images, gitlab-runner-custom-executors], addflavor: true }
 - { setname: gitflow,                  name: [git-flow,git_flow] }
 - { setname: gitg,                     name: gitg0, family: freebsd }
 - { setname: githud,                   name: "haskell:githud" }


### PR DESCRIPTION
Can you review the CE vs. EE comment in the commit here? Is this the way to handle a split release like this where the same base code is released with two licenses and some package differences upstream but that are always version-synced?