### PR TITLE
Ignore bad lyricue version in Ubuntu universe

### DIFF
--- a/900.version-fixes/l.yaml
+++ b/900.version-fixes/l.yaml
@@ -54,4 +54,5 @@
 - { name: lynx,                        verpat: "([0-9]+\\.[0-9]+\\.[0-9]+)[_.~-]?(dev|pre)[_.-]?([0-9]+)", setver: $1$2$3, devel: true, incorrect: false }
 - { name: lynx,                        verpat: "([0-9]+\\.[0-9]+\\.[0-9]+)[_.~-]?(rel)[_.-]?([0-9]+)", setver: $1$2$3, incorrect: false }
 - { name: lynx,                        verpat: ".*pre.*",            ruleset: gentoo,      incorrect: true } # 'dev' versions incorrectly named as 'pre'
+- { name: lyricue,                     verpat: ".*isreally.*",                             incorrect: true } # if it says "is really" then it _not_ what it says on the tin
 - { name: lz4,                         verpat: "[0-9]+",                                   ignore: true }


### PR DESCRIPTION
Somebody did an oops and bumped the version number instead of the package build number. 4.0.12 is the lest release, except for on Ubuntu where an otherwise unknown release 4.0.13 fixes a packaging issue, but is actually 4.0.12 code underneath.

I don't know how to fix this properly (compare 4.0.13 as if it was 4.0.12 if labeled "is really"). Is there a way to parse this string and use the "actual" number instead of the reported one for comparison purposes? E.g. parse `4.0.13isactually4.0.12` as if it was `4.0.12`?