### PR TITLE
Merge Mattermost packages by flavor

### DIFF
--- a/800.renames-and-merges/m.yaml
+++ b/800.renames-and-merges/m.yaml
@@ -26,6 +26,7 @@
 - { setname: mate-control-center,      name: mate-control-center-gtk2, addflavor: gtk2 }
 - { setname: mathics,                  name: "python:mathics" }
 - { setname: matio,                    name: libmatio }
+- { setname: mattermost,               name: [mattermost-server, mattermost-webapp], addflavor: true }
 - { setname: matrix-synapse,           name: "python:matrix-synapse" }
 - { setname: maven-shell,              name: mvnsh }
 - { setname: mbedtls,                  name: mbedtls10 }


### PR DESCRIPTION
Note the `mattermost-webapp` & `mattermost-server` packages are synchronized upstream and distributed in a single combined `mattermost` release, some downstream packagers split them out again, hence the flavors. On the other hand `mattermost-desktop` is on a separate release schedule.