### PR TITLE
Catch all Gentoo *-bin ebuilds as flavors

### DIFF
--- a/100.prefix-suffix.yaml
+++ b/100.prefix-suffix.yaml
@@ -34,6 +34,8 @@
 - { ruleset: freebsd,         namepat: "(.*)-(py[0-9]+)", setname: $1, addflavor: $2 }
 - { ruleset: freebsd,         namepat: "(linux-c[67])-(.*)", setname: $2, addflavor: $1, legacy: true }
 
+- { ruleset: gentoo,          namepat: "(.*)-(bin)", setname: $1, addflavor: $2 }
+
 - { ruleset: guix,            namepat: "(guile)([0-9.]+)(-.*)", setname: $1$3, addflavor: $1$2 }
 
 # XXX: expand this onto whole haiku-apps category


### PR DESCRIPTION
Split out of #61 — 

> Also note that the AUR `*-bin` rule caught [mattermost-desktop-bin](https://repology.org/metapackage/mattermost-desktop/versions) for AUR, but not for [Gentoo or Funtoo](https://repology.org/metapackage/mattermost-desktop-bin/versions). I added a similar rule for Gentoo, but I wasn't sure what to use for Funtoo because there are zero examples of rules involving it in the set. Does it inherit from Gentoo?