### PR TITLE
Ignore ale snapshot posing as non-existent release

### DIFF
--- a/850.split-ambiguities/a.yaml
+++ b/850.split-ambiguities/a.yaml
@@ -6,6 +6,8 @@
 
 - { name: avogadro, verge: "1.8", setname: avogadro2 } # actually it starts with 1.90, but also cover strange 1.9 from KDE Neon
 
+- { name: ale, wwwpart: aleditor, setname: aleditor }
+
 - { name: allure, wwwpart: allureofthestars, setname: allureofthestars }
 - { name: allure, wwwpart: allure-framework/allure2, setname: allure-report }
 - { name: allure, warning: "please classify me" }


### PR DESCRIPTION
The offending recipe is here:

https://github.com/haikuports/haikuports/blob/master/haiku-libs/ale/ale-0.9.1.recipe

It fetches a hard coded git commit and packages as the next release
number.