### PR TITLE
Cleanup python ISBN related module names

### DIFF
--- a/800.renames-and-merges/python.yaml
+++ b/800.renames-and-merges/python.yaml
@@ -43,6 +43,7 @@
 - { setname: "python:ipython_genutils", name: [ipython-genutils,ipython_genutils] }
 - { setname: "python:ipywidgets",      name: ["python:jupyter_ipywidgets","python:jupyter_ipywidgets-doc",ipywidgets,jupyter-ipywidgets] }
 - { setname: "python:irc",             name: "python:irclib" }
+- { setname: "python:isbnlib",         name: isbnlib }
 - { setname: "python:jade-application-kit", name: jade-application-kit }
 - { setname: "python:jaraco.classes",   name: ["python:jaraco-classes",jaraco.classes] }
 - { setname: "python:jaraco.collections", name: "python:jaraco-collections" }
@@ -102,6 +103,7 @@
 - { setname: "python:pygobject3",      name: [pygobject3-common,pygobject3-python3], addflavor: true }
 - { setname: "python:pygpgme",         name: pygpgme }
 - { setname: "python:pygtk",           name: ["python:gtk","python:gtk2","python:pygtk","python:pygtk2",pygtk,pygtk2,pygtk2.0] }
+- { setname: "python:pyisbn",          name: "python:isbn" }
 - { setname: "python:pylint",          name: [pylint-gui,pylint-py27,pylint3,pylint3-gui] }
 - { setname: "python:pyode",           name: "python:ode" }
 - { setname: "python:pypoppler",       name: ["python:poppler","python:python-poppler"] }


### PR DESCRIPTION
* What is currently aliased as `python:isbn` is actually most commonly known as `pyisbn`.
* The current `isbnlib` and `python:isbnlib` are the same things.