### PR TITLE
Fix Apache versions schemes

### DIFF
--- a/900.version-fixes/a.yaml
+++ b/900.version-fixes/a.yaml
@@ -35,6 +35,9 @@
 - { name: aspcud,                      ver: "2011.03.17",                                  ignore: true }
 - { name: assaultcube,                 verpat: "[0-9]{8}",                                 ignore: true }
 - { name: apache,                      verpat: "2\\.[0-9]*[13579]\\..*",                   devel: true }
+- { name: apache20,                                                                        legacy: true }
+- { name: apache22,                                                                        legacy: true }
+- { name: apache25,                                                                        devel: true }
 - { name: apitrace,                                                                        noscheme: true }
 - { name: "apmod:rpaf",                verpat: "2015.*",             family: [ arch ],     ignore: true }
 - { name: appmenu-qt,                  verpat: "(.*)\\+.*",                                setver: "$1" } # aosc snapshot


### PR DESCRIPTION
Packages labeled apache2 are likely supposed to be 2.4, but packages
with names of apache20 or apache22 are likely legacy, not outdated.

Meanwhile apache25 is devel. There is a catch all rule for odd numbered
versions, but it isn't catching e.g. the AUR apache25 package.