### PR TITLE
Fix Okteta versioning

### DIFF
--- a/900.version-fixes/o.yaml
+++ b/900.version-fixes/o.yaml
@@ -7,6 +7,7 @@
 - { name: octomap,                     verpat: "[0-9a-f]{40}",                             incorrect: true } # commit hash
 - { name: odoo,                        verpat: ".*20[0-9]{6}",                             snapshot: true }
 - { name: ogre,                        verpat: "2.*",                                      ignore: true }
+- { name: okteta,                      verpat: "(4|15|16|17|18).*",                        outdated: true }  # went from following KDE versioning to its own 0.x/1.x-based versioning
 - { name: ollydbg,                     verpat: "[0-9]{3}.*",                               incorrect: true } # it's 1.10, 2.0, 2.01g
 - { name: onioncat,                    verpat: "0\\.2\\.2\\.r[0-9]+.*",                    any_is_patch: true } # https://www.cypherpunk.at/ocat/download/Source/stable/
 - { name: onioncat,                    ver: "0\\.2\\.2",                                   incorrect: true }


### PR DESCRIPTION
Okteta went from following KDE Applications versioning (4.x, 15.xx.x, ...)
to its own internal versioning scheme, which means the current newest is
0.25.2, not 17.12.3.

Upstream discussion:
https://mail.kde.org/pipermail/distributions/2018-May/000281.html