### PR TITLE
Split CRUX rc scripts out of rc shell

### DIFF
--- a/850.split-ambiguities/r.yaml
+++ b/850.split-ambiguities/r.yaml
@@ -3,6 +3,8 @@
 - { name: racer, wwwpart: hippo, setname: racer-game }
 - { name: racer, setname: "rust:racer" }
 
+- { name: rc, wwwpart: crux, setname: rc-crux }
+
 - { name: rescue, wwwpart: rescue.sourceforge.net, setname: rescue-max }
 
 - { name: rex, wwwpart: gnu.org, setname: rex-gray } # https://puszcza.gnu.org.ua/projects/rex


### PR DESCRIPTION
'rc' is used by most distributions (Adélie, Arch, Debian, Fedora, ...)
for the [Plan 9 shell](http://tobold.org/article/rc).  CRUX uses 'rc' for
their init scripts (/etc/rc.conf et al).  This is not the same package.