### PR TITLE
Fix two issues with dmraid versioning

### DIFF
--- a/900.version-fixes/d.yaml
+++ b/900.version-fixes/d.yaml
@@ -38,6 +38,7 @@
 - { name: distorm,                     verpat: "20[0-9]{6}.*",                             ignore: true } # freebsd garbage
 - { name: djvulibre,                   ver: "3.5.27.1",                                    ignore: true }
 - { name: dkms,                        ver: "2.022.0",                                     ignore: true } # gobolinux fake
+- { name: dmraid,                      ver: "1.0.0",                 family: [mageia,openmandriva,pclinuxos,pld], incorrect: true } # it's 1.0.0rc16
 - { name: dnrd,                        ver: "2.20.4",                ruleset: aix,         incorrect: true }
 - { name: dnrd,                                                      ruleset: aix,         untrusted: true }
 - { name: dnscap,                      verpat: "[0-9]{3,}",                                ignore: true }


### PR DESCRIPTION
* Mageia, OpenMandriva, PCLinuxOS, and PLD put 'rc16' in the 'pkgrel'
  field instead of the version, so it looks like they are shipping 1.0.0.
  Such a version does not exist.

* Arch and its derivatives, KaOS, and SliTaz add an extraneous '.3' or
  '-3' to the version number.  This appears to be an Arch patchset and
  has nothing to do with upstream.

(Hopefully I have understood verpat correctly.  If not, please comment and I will amend this.)