### PR TITLE
Fix version for qpdfview

### DIFF
--- a/900.version-fixes/q.yaml
+++ b/900.version-fixes/q.yaml
@@ -13,6 +13,7 @@
 - { name: qgis,                        verpat: ".*20[0-9]{6}",                             snapshot: true }
 - { name: qhull,                       ver: ["2015.7.2.0","2015.2-2"],                     incorrect: true }
 - { name: qlipper,                     verpat: "20[0-9]{6}.*",                             snapshot: true }
+- { name: qpdfview,                    ver: "0.4.17",                                      incorrect: true } # skipped upstream
 - { name: qps,                         verpat: "20[0-9]{6}.*",                             snapshot: true }
 - { name: qrfcview,                    ver: "1.0.0",                 family: openbsd,      successor: true } # uses unofficial fork (dead as well)
 - { name: qt5-webkit,                  ver: "5.212.0",               family: [fedora,sisyphus], incorrect: true } # lie, it's 5.212.0alpha2


### PR DESCRIPTION
Upstream specifically stated[1] that 0.4.17 will not be released.

Anyone claiming to ship 0.4.17 is shipping a git checkout, not a release.

[1]: https://launchpad.net/qpdfview/+announcement/14588