### PR TITLE
Fix ALT Sisyphus' incorrect python:random2 package version

### DIFF
--- a/900.version-fixes/python.yaml
+++ b/900.version-fixes/python.yaml
@@ -29,6 +29,7 @@
 - { name: "python:pyspatialite",       ver: "3.0.1",                 noruleset: pypi,      incorrect: true } # it's 3.0.1-alpha-0
 - { name: "python:pyspatialite",       verpat: "(.*)(?:[_-]alpha[_-])(.*)",                setver: "$1alpha$2" }
 - { name: "python:pyyaml",             ver: "4.1",                                         outdated: true } # retracted: https://github.com/yaml/pyyaml/issues/211
+- { name: "python:random2",            ver: "1.0.2",                 ruleset: sisyphus,    incorrect: true }  # never released development snapshot
 - { name: "python:sphinx-py3doc-enhanced-theme", ver: "2.4.0",       ruleset: pld,         incorrect: true }
 - { name: "python:sphinx-py3doc-enhanced-theme",                     ruleset: pld,         untrusted: true }
 - { name: "python:sphinx-rtd-theme",   verpat: ".*[ab].*",                                 devel: true }


### PR DESCRIPTION
The PyPI entry[1] states the current version is 1.0.1.
GitHub shows a single commit changing 'development' to 1.0.2[2],
but no work was ever done after that.

[1]: https://pypi.org/project/random2/
[2]: https://github.com/strichter/random2