### PR TITLE
Merge three packages from OpenSUSE repos into their appropriate metapackages

### DIFF
--- a/800.renames-and-merges/f.yaml
+++ b/800.renames-and-merges/f.yaml
@@ -39,7 +39,7 @@
 - { setname: firefox,                  namepat: "firefox-esr[0-9.-]*" }
 - { setname: firefox,                  namepat: "firefox-esr[0-9.-]*(-gtk2|-privacy|-unwrapped)", addflavor: $1 }
 - { setname: firefox,                  namepat: "firefox[0-9.-]*" }
-- { setname: firefox,                  namepat: "mozilla-?firefox" }
+- { setname: firefox,                  name: [mozilla-firefox,mozillafirefox] }
 - { setname: firefox-beta-i18n,        namepat: "firefox-beta-i18n-.*" }
 - { setname: firefox-esr-i18n,         namepat: "firefox-esr-(i18n-.*)", addflavor: $1 }
 - { setname: firefox-esr-l10n,         namepat: "firefox-esr[0-9.-]*-l10n" }

--- a/800.renames-and-merges/f.yaml
+++ b/800.renames-and-merges/f.yaml
@@ -39,7 +39,7 @@
 - { setname: firefox,                  namepat: "firefox-esr[0-9.-]*" }
 - { setname: firefox,                  namepat: "firefox-esr[0-9.-]*(-gtk2|-privacy|-unwrapped)", addflavor: $1 }
 - { setname: firefox,                  namepat: "firefox[0-9.-]*" }
-- { setname: firefox,                  name: mozilla-firefox }
+- { setname: firefox,                  namepat: "mozilla-?firefox" }
 - { setname: firefox-beta-i18n,        namepat: "firefox-beta-i18n-.*" }
 - { setname: firefox-esr-i18n,         namepat: "firefox-esr-(i18n-.*)", addflavor: $1 }
 - { setname: firefox-esr-l10n,         namepat: "firefox-esr[0-9.-]*-l10n" }

--- a/800.renames-and-merges/j.yaml
+++ b/800.renames-and-merges/j.yaml
@@ -33,7 +33,7 @@
 - { setname: json-c,                   name: emscripten-json-c, addflavor: emscripten }
 - { setname: json-glib,                name: libjson-glib }
 - { setname: jsonrpc-glib,             name: libjsonrpc-glib }
-- { setname: jss                       name: mozilla-jss }
+- { setname: jss,                      name: mozilla-jss }
 - { setname: juffed,                   name: juffed-qt5, addflavor: true }
 - { setname: jumpnbump,                name: jump-n-bump }
 - { setname: jungledisk,               name: [junglediskserver,junglediskservermanagement,junglediskworkgroup], addflavor: true }

--- a/800.renames-and-merges/j.yaml
+++ b/800.renames-and-merges/j.yaml
@@ -33,6 +33,7 @@
 - { setname: json-c,                   name: emscripten-json-c, addflavor: emscripten }
 - { setname: json-glib,                name: libjson-glib }
 - { setname: jsonrpc-glib,             name: libjsonrpc-glib }
+- { setname: jss                       name: mozilla-jss }
 - { setname: juffed,                   name: juffed-qt5, addflavor: true }
 - { setname: jumpnbump,                name: jump-n-bump }
 - { setname: jungledisk,               name: [junglediskserver,junglediskservermanagement,junglediskworkgroup], addflavor: true }

--- a/800.renames-and-merges/n.yaml
+++ b/800.renames-and-merges/n.yaml
@@ -63,7 +63,7 @@
 - { setname: npapi-vlc,                name: npapi-vlc-gtk3 }
 - { setname: npm,                      namepat: "npm[0-9.-]+" }
 - { setname: npth,                     name: libnpth }
-- { setname: nspr                      name: mozilla-nspr }
+- { setname: nspr,                     name: mozilla-nspr }
 - { setname: nss,                      name: mozilla-nss }
 - { setname: nss-ldap,                 name: libnss-ldap }
 - { setname: ntfs-3g,                  name: ["fusefs:ntfs","fusefs:ntfs-3g",ntfs-3g-fuse,ntfs-3g-ntfsprogs,ntfsprogs,ntfs3g,libntfs-3g,libntfs] }

--- a/800.renames-and-merges/n.yaml
+++ b/800.renames-and-merges/n.yaml
@@ -63,6 +63,7 @@
 - { setname: npapi-vlc,                name: npapi-vlc-gtk3 }
 - { setname: npm,                      namepat: "npm[0-9.-]+" }
 - { setname: npth,                     name: libnpth }
+- { setname: nspr                      name: mozilla-nspr }
 - { setname: nss,                      name: mozilla-nss }
 - { setname: nss-ldap,                 name: libnss-ldap }
 - { setname: ntfs-3g,                  name: ["fusefs:ntfs","fusefs:ntfs-3g",ntfs-3g-fuse,ntfs-3g-ntfsprogs,ntfsprogs,ntfs3g,libntfs-3g,libntfs] }


### PR DESCRIPTION
The various OpenSUSE repos each have packages as follows:
* `mozilla-jss`
* `mozilla-nspr`
* `mozillafirefox`
* `mozillafirefox-branding-opensuse`

The first three appear to be equivalent to the metapackages `jss`, `nspr`, and
`firefox` respectively.

This PR amends one and adds two rename rules so as to merge the first three into their correct metapackages, whilst leaving the fourth intact.

----

(An alternate approach would be a single OpenSUSE-specific rule that removes the `mozilla` prefix from all four. As there already exists a metapackage called `firefox-branding-iceweasel`, one called `firefox-branding-opensuse` wouldn't seem too out of place.)