### PR TITLE
Merge package "pdl" into "perl:pdl"

### DIFF
--- a/800.renames-and-merges/perl.yaml
+++ b/800.renames-and-merges/perl.yaml
@@ -10,5 +10,6 @@
 - { setname: "perl:gearman-server",    name: gearman-server }
 - { setname: "perl:goocanvas2",        name: "perl:goo-canvas2" }
 - { setname: "perl:moo",               name: "perl:moo-2" }
+- { setname: "perl:pdl",               name: "pdl" }
 - { setname: "perl:search-xapian",     namepat: "perl:search-xapian[0-9.-]+" }
 #- { setname: "perl:libwww",            name: libwww-perl }


### PR DESCRIPTION
It appears that most perl packages are listed as "perl:*" so this change should make the Perl Data Language (pdl) consistent with that usage.