### PR TITLE
merge solc into solidity

### DIFF
--- a/800.renames-and-merges/s.yaml
+++ b/800.renames-and-merges/s.yaml
@@ -116,6 +116,7 @@
 - { setname: sogo,                     name: [gnustep-sogo,gnustep-sogo3,sogo4] }
 - { setname: sogo,                     name: [sogo2-activesync,sogo3-activesync,sogo4-activesync], addflavor: activesync }
 - { setname: soil,                     name: libsoil }
+- { setname: solidity,                 name: solc }
 - { setname: sope,                     name: sope4 }
 - { setname: sopwith,                  name: [sdlsopwith,sdl-sopwith] }
 - { setname: sorcer,                   name: [lv2-sorcer,openav-sorcer,openav-sorcer-lv2,sorcer-lv2] }


### PR DESCRIPTION
`solc` is only used by [nixpkgs](https://repology.org/metapackage/solc/versions).