### PR TITLE
Note development versions of kpmcore

### DIFF
--- a/900.version-fixes/k.yaml
+++ b/900.version-fixes/k.yaml
@@ -139,6 +139,7 @@
 - { name: korganizer,                  verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
 - { name: kpat,                        verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
 - { name: kpimtextedit,                verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
+- { name: kpmcore,                     verpat: "3\\.[89][0-9]\\..*",                       devel: true }
 - { name: kqlives,                     verpat: "20[0-9]{6}",                               ignore: true }
 - { name: krank,                       verpat: "20[0-9]{6}.*",                             ignore: true }
 - { name: krb5,                        ver: "1.17",                  ruleset: fedora,      incorrect: true } # beta1


### PR DESCRIPTION
3.8x.y and 3.9x.y are development versions, not stable releases.