### PR TITLE
Note mkfontdir 1.2.0 does not exist

### DIFF
--- a/900.version-fixes/m.yaml
+++ b/900.version-fixes/m.yaml
@@ -85,6 +85,7 @@
 - { name: mixxx,                                                     ruleset: [aosc,fedora,kaos], untrusted: true }
 - { name: mkchromecast,                ver: "0.3.9",                 ruleset: unitedrpms,  incorrect: true }
 - { name: mkchromecast,                                              ruleset: unitedrpms,  untrusted: true } # accused of fake 0.3.9
+- { name: mkfontdir,                   ver: "1.2.0",                                       incorrect: true } # gentoo made fake 1.2.0 to pull in mkfontscale which replaces it
 - { name: mkgmap,                      verpat: "(?:0\\.0\\.0svn|r)([0-9]{4,})",            setver: $1 }
 - { name: mkgmap-splitter,             verpat: "(?:0\\.0\\.0svn|r)([0-9]{3,})",            setver: $1 }
 - { name: mkinitrd,                    verpat: "20[0-9-]{8}",                              incorrect: true } # t2 garbage


### PR DESCRIPTION
Gentoo has made a fake mkfontdir 1.2.0 package because mkfontscale 1.2.0 replaces it.  This is obviously incorrect (it is dead upstream, there is no 1.2.0 release and never will be).