### PR TITLE
Remove obsolete merge for AutoKey

### DIFF
--- a/800.renames-and-merges/a.yaml
+++ b/800.renames-and-merges/a.yaml
@@ -198,7 +198,7 @@
 - { setname: autodia,                  name: "perl:autodia" }
 - { setname: autoflake,                name: "python:autoflake" }
 - { setname: autofs,                   name: autofs5 }
-- { setname: autokey,                  name: [autokey-py3,"python:autokey"] }
+- { setname: autokey,                  name: "python:autokey" }
 - { setname: automake,                 namepat: "automake-?[0-9.]+" } # do we need splits for this?
 - { setname: automoc,                  namepat: "automoc[0-9]+" }
 - { setname: autopep8,                 name: "python:autopep8" }


### PR DESCRIPTION
The AUR maintainer updated the package name,
so one of the merge rules is not necessary any more.
https://aur.archlinux.org/packages/autokey/