### PR TITLE
Split redo between jdebp and apenwarr versions

### DIFF
--- a/850.split-ambiguities/r.yaml
+++ b/850.split-ambiguities/r.yaml
@@ -12,6 +12,12 @@
 - { name: rdd, wwwpart: r043v, setname: rdd-redis }
 - { name: rdd, warning: "please classify me" }
 
+- { name: redo, wwwpart: jdebp.eu, setname: redo-jdebp }
+- { name: redo, wwwpart: [redo.readthedocs.io, github.com/apenwarr, apenwarr.ca], setname: redo-apenwarr }
+- { name: redo, ruleset: exherbo, setname: redo-jdebp }
+- { name: redo, ruleset: solus, setname: redo-apenwarr }
+- { name: redo, warning: "please classify me" }
+
 - { name: rem, wwwpart: kykim, setname: rem-kykim }
 
 - { name: rescue, wwwpart: rescue.sourceforge.net, setname: rescue-max }


### PR DESCRIPTION
There are multiple implementations of redo. Repology currently shows 2 of them under the same name. One by jdebp and one by apenwarr. Split them into redo-jdebp and redo-apenwarr.

Fixes #189