### PR TITLE
Delete rstudio preview version-fixes rule

### DIFF
--- a/900.version-fixes/r.yaml
+++ b/900.version-fixes/r.yaml
@@ -48,7 +48,6 @@
 - { name: rss-glx,                     verpat: "0\\.9[0-9]+",        ruleset: openindiana, incorrect: true } # it's 0.9.1, not 0.91
 - { name: rss-glx,                     ver: "1.0",                   ruleset: t2,          incorrect: true } # different url, not found on sourceforge
 - { name: rss-glx,                                                   ruleset: t2,          untrusted: true }
-- { name: rstudio,                     verpat: "1\\.2\\.[0-9]+",                           devel: true, maintenance: true } # 1.2 are currently preview releases, 1.1 is mainline
 - { name: rtl-sdr,                     verpat: ".*20[0-9]{6}",                             snapshot: true }
 - { name: rtl-sdr,                     verge: "20000000", verlt: "20180827",               outdated: true } # 0.6.0 from 2018-08-27
 - { name: rtl-sdr,                     ver: "0.20130412",                                  outdated: true, disposable: true }


### PR DESCRIPTION
The rule introduced in https://github.com/repology/repology-rules/pull/94 can now be discontinued with the release of rstudio 1.2 as the mainline/stable release (https://www.rstudio.com/products/rstudio/release-notes/).