### PR TITLE
Normalize Cygwin cross-package names

### DIFF
--- a/100.prefix-suffix.yaml
+++ b/100.prefix-suffix.yaml
@@ -22,6 +22,12 @@
 
 - { ruleset: chocolatey,      namepat: "(.*)\\.(install|portable|commandline)", setname: $1, addflavor: $2 }
 
+# cygwin cross-packages
+- { ruleset: cygwin,          namepat: "cygwin(32|64)", setname: "cygwin$1-cygwin" }
+- { ruleset: cygwin,          namepat: "cygwin(32|64)-default-manifest", setname: "cygwin$1-windows-default-manifest" }
+- { ruleset: cygwin,          namepat: "cygwin32-(.*)", setname: $1, addflavor: i686-pc-cygwin }
+- { ruleset: cygwin,          namepat: "cygwin64-(.*)", setname: $1, addflavor: x86_64-pc-cygwin }
+
 - { ruleset: deb_multimedia,  namepat: "(.*)-dmo", setname: "$1" }
 
 - { ruleset: debuntu,         namepat: "(.*)-lts-(quantal|raring|saucy|trusty|utopic|vivid|wily|xenial|yakkety|zesty|artful|bionic)", setname: $1 }


### PR DESCRIPTION
This normalizes the names of packages for x86/x86_64 Cygwin cross-compilation.

This probably isn't the right way to do this, and a proper solution depends on https://github.com/repology/repology/issues/170 and https://github.com/repology/repology-rules/issues/10.

Note that there are also some djgpp cross-packages, which also need similar handling.
