### PR TITLE
Set exherbo/void browserpass as browserpass-native

### DIFF
--- a/850.split-ambiguities/b.yaml
+++ b/850.split-ambiguities/b.yaml
@@ -77,7 +77,8 @@
 
 - { name: browserpass, wwwpart: browserpass-native, setname: browserpass-native }
 - { name: browserpass, wwwpart: [browserpass-extension,dannyvankooten], setname: browserpass-extension }
-- { name: browserpass, ruleset: [debuntu,exherbo,void], setname: browserpass-extension }
+- { name: browserpass, ruleset: debuntu, setname: browserpass-extension }
+- { name: browserpass, ruleset: [exherbo,void], setname: browserpass-native }
 - { name: browserpass, warning: "please classify me" }
 
 - { name: bsc, wwwpart: [besc,beesoft], setname: beesoft-commander }


### PR DESCRIPTION
The exherbo package is the outdated native part of browserpass-legacy
The void package is the same as other browserpass-native packages,