### PR TITLE
Add verignore for multibootusb

### DIFF
--- a/900.version-fixes/m.yaml
+++ b/900.version-fixes/m.yaml
@@ -138,6 +138,7 @@
 - { name: mtd-utils,                                                 ruleset: maemo,       ignore: true } # fork?
 - { name: mtd-utils,                   verpat: "[0-9]{6}",                                 incorrect: true } # slackware garbage
 - { name: mtxclient,                   verpat: "20[-0-9]{8}",                              snapshot: true }
+- { name: multibootusb,                ver: "9.3.0",                 ruleset: freshcode,   incorrect: true }
 - { name: multimon-ng,                 verpat: "20[0-9]{6}.*",                             ignore: true }
 - { name: mumble,                                                    ruleset: kaos,        ignore: true } # snapshot with random version
 - { name: mumble,                      ver: "1.2.89",                                      incorrect: true }


### PR DESCRIPTION
I don't have any clue where this version comes from both Sourceforge and Github only have 9.2.0 as newest version.