### PR TITLE
Sort out OpenFOAM

### DIFF
--- a/800.renames-and-merges/o.yaml
+++ b/800.renames-and-merges/o.yaml
@@ -55,6 +55,7 @@
 - { setname: opendnssec,               name: opendnssec2 }
 - { setname: openerp,                  namepat: "openerp[0-9.-]+" }
 - { setname: openfoam,                 namepat: "openfoam[0-9x.-]+" }
+- { setname: openfoam-plus,            namepat: "openfoam-esi.*" }
 - { setname: openhab,                  name: openhab-beta, weak_devel: true }
 - { setname: openhab,                  name: openhab2 }
 - { setname: openhab-addons,           name: openhab2-addons }

--- a/850.split-ambiguities/o.yaml
+++ b/850.split-ambiguities/o.yaml
@@ -42,6 +42,8 @@
 
 - { name: openbox-themes, wwwpart: openbox.org, setname: openbox, addflavor: themes } # slitaz
 
+- { name: openfoam, verpat: "v?[0-9]{4}", setname: openfoam-plus }
+
 - { name: orange, wwwpart: synce, setname: orange-synce }
 - { name: orange, summpart: cabinet, setname: orange-synce }
 - { name: orange, wwwpart: biolab, setname: orange-biolab }

--- a/900.version-fixes/o.yaml
+++ b/900.version-fixes/o.yaml
@@ -50,8 +50,8 @@
 - { name: opendbx,                     ver: "1.5.0",                                       devel: true } # https://linuxnetworks.de/doc/index.php?title=OpenDBX/Download; XXX probably needs pattern, but the devel scheme is unknown
 - { name: opendkim,                    ver: "2.11.0",                ruleset: [sisyphus,fedora], incorrect: true } # it's 2.11.0.alpha0: https://sourceforge.net/projects/opendkim/files/
 - { name: opendkim,                                                  ruleset: [sisyphus,fedora], untrusted: true } # accused of fake 2.11.0
-- { name: openfoam,                    verpat: "[0-9]{4}",                                 ignore: true } # ??? correct version is 6 or 6.YYYYMMDD
 - { name: openfoam,                    verpat: ".*20[0-9]{6}",                             devel: true } # XXX: alternative schema; https://github.com/OpenFOAM/OpenFOAM-6/releases
+- { name: openfoam-plus,               verpat: "[0-9]{4}",                                 setver: "v$0" }
 - { name: openjade,                    verpat: ".*(p|pre|devel)[0-9]*",                    devel: true }
 - { name: openjade,                    ver: "1.3.3",                 ruleset: [pclinuxos,mageia,openpkg,pld], incorrect: true } # fake, it's 1.3.3pre1
 - { name: openjfx,                     verpat: "8\\.0\\..*",                               ignore: true } # fedora; the official scheme is e.g. 8u151b12


### PR DESCRIPTION
  - Consistently use name `openfoam-plus` for openfoam.com fork
  - Rename packages with `yymm` version scheme to `openfoam-plus`
  - yymm -> vyymm

Fixes #231