### PR TITLE
shotcut: set v19.08.05 as devel

### DIFF
--- a/900.version-fixes/s.yaml
+++ b/900.version-fixes/s.yaml
@@ -67,6 +67,7 @@
 - { name: shmux,                       verpat: ".*20[0-9]{6}",                             snapshot: true }
 - { name: shotcut,                     verpat: "[0-9]{6,}.*",                              incorrect: true } # aur; it's not 180102, but 18.01
 - { name: shotcut,                     verpat: ".+20[0-9]{6}",                             snapshot: true } # funtoo
+- { name: shotcut,                     ver: "19.08.05",                                    maintenance: true, devel: true }
 - { name: shotgun-debugger,            wwwpart: msarnoff,                                  successor: true }
 - { name: shotwell,                    verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true } # assumed
 - { name: sia,                         verpat: "20[0-9]{6}",                               snapshot: true }


### PR DESCRIPTION
[v19.08.05][0] is marked as BETA / pre-release

[0]:https://github.com/mltframework/shotcut/releases/tag/v19.08.05