### PR TITLE
Merge for FreeBSD elm-format

### DIFF
--- a/800.renames-and-merges/e.yaml
+++ b/800.renames-and-merges/e.yaml
@@ -39,6 +39,7 @@
 - { setname: elfutils,                 name: elfutils-libelf }
 - { setname: elixir,                   name: elixir-lang }
 - { setname: elkcode,                  name: elk-chemistry }
+- { setname: elm-format,               name: "haskell:elm-format" }
 - { setname: elm-format,               namepat: "elm-format[0-9.-]+(?:-exp)?" }
 - { setname: elm-lang,                 name: elm-platform }
 - { setname: elm-mua,                  name: elm-me, addflavor: me }


### PR DESCRIPTION
This is intended to merge https://repology.org/project/haskell:elm-format/versions into https://repology.org/project/elm-format/versions