### PR TITLE
Add Adélie php rule and fix "Apache Lucene" from Wikidata

### DIFF
--- a/500.wildcard.yaml
+++ b/500.wildcard.yaml
@@ -128,6 +128,7 @@
 - { setname: "php70:$1", addflag: wconce, noflag: [wconce,not_php], namepat: "php-7\\.0-ext-(.*)", ruleset: openindiana }
 - { setname: "php:$1", addflag: wconce, noflag: [wconce,not_php], namepat: "php[0-9]*(?:-pear|-pecl)?-(.*)", ruleset: pld }
 - { setname: "php:$1", addflag: wconce, noflag: [wconce,not_php], namepat: "libphp-(.*)", ruleset: debuntu }
+- { setname: "php:$1", addflag: wconce, noflag: [wconce,not_php], namepat: "php[0-9]*-(.*)", ruleset: [adelie] }
 
 # Python
 - { setname: "python:$0", addflag: wconce, noflag: [wconce,not_python], ruleset: aosc, category: python }


### PR DESCRIPTION
* Add a rule to rewrite [e.g. `php7-apcu`](https://repology.org/project/php7-apcu/versions) and any future packages to `php:` namespace for Adélie.
* Rewrite "Apache Lucene" to "lucene" so that [Wikidata doesn't corrupt the current version of clucene](https://repology.org/project/clucene/versions).