### PR TITLE
Set flavors for older versions of elm-format

### DIFF
--- a/800.renames-and-merges/e.yaml
+++ b/800.renames-and-merges/e.yaml
@@ -40,7 +40,8 @@
 - { setname: elixir,                   name: elixir-lang }
 - { setname: elkcode,                  name: elk-chemistry }
 - { setname: elm-format,               name: "haskell:elm-format" }
-- { setname: elm-format,               namepat: "elm-format[0-9.-]+(?:-exp)?" }
+- { setname: elm-format,               namepat: "elm-format(?:-exp)?(?:-bin)?" }
+- { setname: elm-format,               namepat: "elm-format-([0-9.]+)(?:-exp)?(?:-bin)?", addflavor: "elm$1" }
 - { setname: elm-lang,                 name: elm-platform }
 - { setname: elm-mua,                  name: elm-me, addflavor: me }
 - { setname: elmerfem,                 name: elmer-fem }


### PR DESCRIPTION
Here's what the elm-format versions currently look like:

<img width="731" alt="Screen Shot 2019-08-26 at 4 36 25 PM" src="https://user-images.githubusercontent.com/1222/63730317-b05df600-c81f-11e9-8a73-faed97345b63.png">

This PR is meant to take for instance the `elm-format-0.18-bin` package and give it the flavor "elm0.18"  (it indicates which version of Elm-platform that particular build of elm-format supports).
(as of elm-format 0.8.1, there are no longer flavors; the same elm-format binary works for all versions of Elm)