### PR TITLE
Set proper last version for salt

### DIFF
--- a/900.version-fixes/s.yaml
+++ b/900.version-fixes/s.yaml
@@ -2,6 +2,7 @@
 
 - { name: s25rttr,                     verpat: "20[0-9]{6}",                               devel: true } # official nightlies
 - { name: salmid,                      verpat: "0\\.[0-9]{3}",                             outdated: true } # upstream 0.122 -> 0.1.23 https://github.com/hcdenbakker/SalmID/releases
+- { name: salt,                        verpat: "20[0-9]{2}\\.[0-9]{1,2}",                  devel: true } # 2-part versions are not official releases
 - { name: samurai,                     ver: "0.3.21",                ruleset: freebsd,     incorrect: true }
 - { name: samurai,                                                   ruleset: freebsd,     untrusted: true }
 - { name: sandfox,                     verpat: "20[0-9]{6}",                               snapshot: true }


### PR DESCRIPTION
Salt official releases have a 3-part version scheme, but they also push
2-part tags to github, which are not official releases.

For example the last official release is 2019.2.1. 2019.8 is
available as tag on github, but not as release (and also not available
on pypi, which they consider the official source for releases[0]).

[0]:https://github.com/saltstack/salt/issues/41847