### PR TITLE
Remove old verignore for android-tools

### DIFF
--- a/900.version-fixes/a.yaml
+++ b/900.version-fixes/a.yaml
@@ -84,7 +84,6 @@
 - { name: android-studio,              verpat: "([0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+)([._].*)", setver: $1 } # drop meaningless build numbers
 - { name: android-studio,              verpat: "[0-9]{3}\\..*",                            incorrect: true } # mx fake
 - { name: android-tools,               verpat: "[0-9]{4,}.*",                              ignore: true } # fake
-- { name: android-tools,               verpat: "[0-9]{2,}\\..*",                           incorrect: true } # old debian fake
 - { name: android-tools,               ver: "21",                                          outdated: true } # debian oldstable, assuming ancient version
 - { name: anki,                        ver: "2.1.0",                 ruleset: debuntu,     ignore: true } # fake
 - { name: antimicro,                   verpat: "2\\.24\\.[0-9]+",                          successor: true } # https://github.com/juliagoda/antimicro, abandoned as well


### PR DESCRIPTION
Using the platform-tools tag is the preferred way to version the
android-tools package, this rule did block the "new" version scheme

Reference: https://twitter.com/DanielMicay/status/1151093023440347136
https://bugs.archlinux.org/task/63200

Besides this rule did also block the `10.x` versions.