### PR TITLE
Merge chromium-browser-privacy into ungoogled-chromium

### DIFF
--- a/800.renames-and-merges/u.yaml
+++ b/800.renames-and-merges/u.yaml
@@ -24,6 +24,7 @@
 - { setname: unburden-home-dir,        name: "perl:unburden-home-dir" }
 - { setname: unclutter,                name: unclutter-patched, addflavor: true }
 - { setname: uncrustify,               name: uncrustify0.60 }
+- { setname: ungoogled-chromium,       name: chromium-browser-privacy }
 - { setname: unibilium,                name: libunibilium }
 - { setname: unicorn-engine,           name: ["python:unicorn", unicorn-emulator] }
 - { setname: unicorn-engine,           name: unicorn-bindings, addflavor: bindings }


### PR DESCRIPTION
1) `ungoogled-chromium` is named differently in RPM Fusion in order to prevent [potential legal issues](https://github.com/chromium/chromium/blob/0125cf6/LICENSE#L13-L15).
2) I think `ungoogled-chromium` should not be merged into `chromium` since it's a distinct Chromium-based browser. It has its own [features](https://github.com/Eloston/ungoogled-chromium#feature-overview) etc.
