### PR TITLE
Merge claws-mail plugins

### DIFF
--- a/800.renames-and-merges/claws-mail.yaml
+++ b/800.renames-and-merges/claws-mail.yaml
@@ -1,0 +1,34 @@
+# vim: tabstop=39 expandtab softtabstop=39
+
+- setname: claws-mail
+  name:
+    - claws-mail-address-keeper
+    - claws-mail-archive
+    - claws-mail-archiver
+    - claws-mail-att-remover
+    - claws-mail-attachwarner
+    - claws-mail-bogofilter
+    - claws-mail-bsfilter
+    - claws-mail-clamd
+    - claws-mail-fetchinfo
+    - claws-mail-gdata
+    - claws-mail-libravatar
+    - claws-mail-mailmbox
+    - claws-mail-managesieve
+    - claws-mail-newmail
+    - claws-mail-notification
+    - claws-mail-pdf-viewer
+    - claws-mail-perl
+    - claws-mail-pgp
+    - claws-mail-pgpcore
+    - claws-mail-pgpinline
+    - claws-mail-pgpmime
+    - claws-mail-python
+    - claws-mail-rssyl
+    - claws-mail-smime
+    - claws-mail-spam-report
+    - claws-mail-spamassassin
+    - claws-mail-spamreport
+    - claws-mail-tnef
+    - claws-mail-tnef-parse
+  addflavor: true


### PR DESCRIPTION
These plugins are distributed as part of the claws-mail distribution so the version number is the same as the main package. Some packaging systems have decided to split them out from claws-mail.