### PR TITLE
Add setver for darktable 2.6.3

### DIFF
--- a/900.version-fixes/d.yaml
+++ b/900.version-fixes/d.yaml
@@ -9,6 +9,7 @@
 - { name: darkplaces,                  ver: "20141016",                                    incorrect: true }
 - { name: darkplaces,                                                ruleset: pclinuxos,   untrusted: true } # accused of fake 20141016
 - { name: darktable,                   verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
+- { name: darktable,                   ver: "2.6.3.1",                                     setver: "2.6.3" } # mac osx dedicated rerelease
 - { name: dbus,                        verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
 - { name: dbus-cpp,                    verpat: "(.*)\\+.*",                                setver: "$1" } # aosc snapshot
 - { name: dconf,                       verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }


### PR DESCRIPTION
Version 2.6.3.1 is a mac osx only release, listed under [2.6.3][0]

[0]:https://github.com/darktable-org/darktable/releases/tag/release-2.6.3