### PR TITLE
Merge amazon-ecr-credential-helper

### DIFF
--- a/800.renames-and-merges/a.yaml
+++ b/800.renames-and-merges/a.yaml
@@ -87,6 +87,7 @@
 - { setname: alsa-plugins,             name: alsa-plugins-oss, addflavor: oss }
 - { setname: alsamodularsynth,         name: [alsa-modular-synth, ams] }
 - { setname: amavisd-new,              name: amavisd, ruleset: openpkg }
+- { setname: amazon-ecr-credential-helper, name: docker-credential-helper-ecr }
 - { setname: amber-search,             name: "rust:amber" }
 - { setname: amd-app-sdk,              name: amdapp-sdk }
 - { setname: amp,                      name: "rust:amp" }


### PR DESCRIPTION
https://repology.org/project/amazon-ecr-credential-helper/versions and https://repology.org/project/docker-credential-helper-ecr/versions refer to the same project with the canonical name of amazon-ecr-credential-helper.

Thanks!