### PR TITLE
Combine apl and gnu-apl

### DIFF
--- a/800.renames-and-merges/a.yaml
+++ b/800.renames-and-merges/a.yaml
@@ -125,6 +125,7 @@
 - { setname: apache-commons-lang,      name: [apache-commons-lang-eap6,apache-commons-lang3,commons-lang,jakarta-commons-lang,jakarta-commons-lang3,java-commons-lang,java-commons-lang3,libcommons-lang-java,libcommons-lang3-java] }
 - { setname: apache-orc,               name: orc-tools }
 - { setname: apcupsd,                  name: [apcupsd-x11,apcupsd-cgi] }
+- { setname: apl,                      name: gnu-apl }
 - { setname: appstream,                name: appstream-qt }
 - { setname: appstream-glib,           name: libappstream-glib }
 - { setname: apq,                      name: apq-base } # ravenports


### PR DESCRIPTION
`apl` is known as `gnu-apl` in Homebrew and Linuxbrew.