### PR TITLE
Ignore Alpine Linux git snapshots.

### DIFF
--- a/899.version-fixes.global.yaml
+++ b/899.version-fixes.global.yaml
@@ -54,6 +54,7 @@
 - { verpat: ".*suse",                                                                      incorrect: true }
 - { verpat: ".*r.*", namepat: "php:.*",                              ruleset: freebsd,     devel: true }
 - { verpat: "5\\.[0-9]{2}\\.0",                                      ruleset: kaos_build,  untrusted: true } # accused of faking -rc versions of KDE stuff as release
+- { verpat: "[0-9.]+_git.+",                                         ruleset: alpine,      ignore: true } # snapshots
 
 # nuget is terminally broken and can't handle arbitrary version schemes, so most are garbage
 - {                                                                  ruleset: chocolatey,  untrusted: true }


### PR DESCRIPTION
The recommended way to version git snapshots for projects that have no
releases yet is to use the version pattern: `0_git<commitdate>`. This
way, any actual released version will be considered newer than these
snapshots.

Ignore any version using this pattern as the date is not always
reliable (some use the current date), so it's not a good way to compare.