### PR TITLE
Ignore versions for rtl8821ce

### DIFF
--- a/900.version-fixes/r.yaml
+++ b/900.version-fixes/r.yaml
@@ -68,6 +68,7 @@
 - { name: rtl-sdr,                     verge: "20000000", verlt: "20180827",               outdated: true } # 0.6.0 from 2018-08-27
 - { name: rtl-sdr,                     ver: "0.20130412",                                  outdated: true, disposable: true }
 - { name: rtl8812au,                                                                       noscheme: true }
+- { name: rtl8821ce,                                                                       noscheme: true }
 - { name: rtmpdump,                    verpat: ".*20[0-9]{6}.*",                           ignore: true }
 - { name: rtmpdump,                    verlonger: 2,                                       ignore: true }
 - { name: rtorrent,                    verpat: "20[0-9]{6}.*",                             ignore: true } # nix fake


### PR DESCRIPTION
Upstream has no defined versions.