### PR TITLE
Set altver for darktable-x.y.z.n

### DIFF
--- a/900.version-fixes/d.yaml
+++ b/900.version-fixes/d.yaml
@@ -9,7 +9,7 @@
 - { name: darkplaces,                  ver: "20141016",                                    incorrect: true }
 - { name: darkplaces,                                                ruleset: pclinuxos,   untrusted: true } # accused of fake 20141016
 - { name: darktable,                   verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
-- { name: darktable,                   ver: "2.6.3.1",                                     setver: "2.6.3" } # mac osx dedicated rerelease
+- { name: darktable,                   verlonger: 3,                                       altver: true } # mac osx dedicated rerelease
 - { name: dbus,                        verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
 - { name: dbus,                        relge: "2",                   ruleset: pisi,        incorrect: true }
 - { name: dbus-cpp,                    verpat: "(.*)\\+.*",                                setver: "$1" } # aosc snapshot


### PR DESCRIPTION
The project has an optional 4-component version scheme only for
OSX (.dmg).

Set altver for these releases so that they are not considered newer as
the 3-component version releases.