### PR TITLE
Rename gentoo's dev-vcs/cli to github-cli

### DIFF
--- a/850.split-ambiguities/c.yaml
+++ b/850.split-ambiguities/c.yaml
@@ -100,6 +100,8 @@
 - { name: clean, summpart: "programming language", setname: clean-lang }
 - { name: clean, warning: "please classify me" }
 
+- { name: cli, wwwpart: github.com/cli/cli, setname: github-cli }
+
 - { name: clink, wwwpart: mridgers, setname: clink-cmd }
 - { name: clink, wwwpart: [free-electrons,bootlin.com], setname: clink-symlink }
 - { name: clink, ruleset: pld, setname: clink-net }


### PR DESCRIPTION
Renaming `dev-vcs/cli` to `github-cli` for gentoo's package https://packages.gentoo.org/packages/dev-vcs/cli