### PR TITLE
Merge pikepdf

### DIFF
--- a/800.renames-and-merges/python.yaml
+++ b/800.renames-and-merges/python.yaml
@@ -175,6 +175,7 @@
 - { setname: "python:pep8",            name: pep8 }
 - { setname: "python:pep8-naming",     name: [flake-pep8-naming,pep8-naming,"python:flake8-pep8-naming"] }
 - { setname: "python:phply",           name: phply }
+- { setname: "python:pikepdf",         name: pikepdf }
 - { setname: "python:pillow",          name: pillow }
 - { setname: "python:pillowfight",     name: pillowfight }
 - { setname: "python:pip",             name: pip }


### PR DESCRIPTION
This is my first time working with these rules but I'm quite sure this should merge [pikepdf](https://repology.org/project/pikepdf/versions) into [python:pikepdf](https://repology.org/project/python:pikepdf/versions) so that we have all versions of pikepdf on one page / in one badge.

