### PR TITLE
New rules for Carbs Linux

### DIFF
--- a/100.prefix-suffix.yaml
+++ b/100.prefix-suffix.yaml
@@ -21,7 +21,7 @@
 - { ruleset: buckaroo,        wwwpart: pocoproject.org, setname: poco, addflavor: $0 }
 - { ruleset: buckaroo,        wwwpart: sfml-dev.org, setname: sfml, addflavor: $0 }
 
-- { ruleset: carbs,           namepat: "(.*)-git", ver: "git", setname: $1 } # Note: rolling status set for 'git' versions in 899 ruleset
+- { ruleset: carbs,           namepat: "(.*)-git", ver: "git", setname: $1, rolling: true }
 
 - { ruleset: chocolatey,      namepat: "(.*)\\.(install|portable|commandline)", setname: $1, addflavor: $2 }
 

--- a/100.prefix-suffix.yaml
+++ b/100.prefix-suffix.yaml
@@ -21,6 +21,8 @@
 - { ruleset: buckaroo,        wwwpart: pocoproject.org, setname: poco, addflavor: $0 }
 - { ruleset: buckaroo,        wwwpart: sfml-dev.org, setname: sfml, addflavor: $0 }
 
+- { ruleset: carbs,           namepat: "(.*)-git", ver: "git", setname: $1 } # Note: rolling status set for 'git' versions in 899 ruleset
+
 - { ruleset: chocolatey,      namepat: "(.*)\\.(install|portable|commandline)", setname: $1, addflavor: $2 }
 
 # cygwin cross-packages

--- a/850.split-ambiguities/k.yaml
+++ b/850.split-ambiguities/k.yaml
@@ -22,6 +22,7 @@
 
 - { name: kiss, wwwpart: kipr, setname: kiss-precedence-compiler }
 - { name: kiss, wwwpart: kisslinux, setname: kiss-package-manager }
+- { name: kiss, wwwpart: carbslinux, setname: kiss-package-manager-carbs }
 - { name: kiss, wwwpart: shell, setname: kiss-shell }
 - { name: kiss, warning: "please classify me" }
 

--- a/899.version-fixes.global.yaml
+++ b/899.version-fixes.global.yaml
@@ -8,7 +8,6 @@
 - { verpat: ".*(?:alpha|beta|dev|rc|prerelease|pre)(?:[0-9._-].*)?$",                      devel: true }
 - { verpat: ".*9999",                                                ruleset: gentoo,      rolling: true }
 - { ver: "git",                                                      ruleset: kiss,        rolling: true }
-- { ver: "git",                                                      ruleset: carbs,       rolling: true }
 - { ver: "nightly",                                                                        rolling: true } # e.g. scoop
 
 # global vcs snapshot ignore

--- a/899.version-fixes.global.yaml
+++ b/899.version-fixes.global.yaml
@@ -8,6 +8,7 @@
 - { verpat: ".*(?:alpha|beta|dev|rc|prerelease|pre)(?:[0-9._-].*)?$",                      devel: true }
 - { verpat: ".*9999",                                                ruleset: gentoo,      rolling: true }
 - { ver: "git",                                                      ruleset: kiss,        rolling: true }
+- { ver: "git",                                                      ruleset: carbs,       rolling: true }
 - { ver: "nightly",                                                                        rolling: true } # e.g. scoop
 
 # global vcs snapshot ignore


### PR DESCRIPTION
These patches,

- Specify a seperate package manager wwwpart for kiss-package-manager
- Imitate the versioning rule for git packages