### PR TITLE
Add two new aliases to `fonts:gnu-freefont`

### DIFF
--- a/800.renames-and-merges/fonts/g.yaml
+++ b/800.renames-and-merges/fonts/g.yaml
@@ -188,6 +188,7 @@
 
 - setname: "fonts:gnu-freefont"
   name:
+    - font-freefont-ttf
     - font-gnu-freefont
     - font-gnu-freefont-ttf
     - fonts-freefont

--- a/800.renames-and-merges/fonts/g.yaml
+++ b/800.renames-and-merges/fonts/g.yaml
@@ -188,6 +188,7 @@
 
 - setname: "fonts:gnu-freefont"
   name:
+    - font-gnu-freefont
     - font-gnu-freefont-ttf
     - fonts-freefont
     - fonts-freefont-ttf


### PR DESCRIPTION
- `font-gnu-freefont`, used by Guix: https://guix.gnu.org/packages/font-gnu-freefont-20120503/
- `font-freefont-ttf`, used by Solus: https://dev.getsol.us/source/font-freefont-ttf/