### PR TITLE
Add `media-fonts/droid` to `fonts:droid`

### DIFF
--- a/800.renames-and-merges/fonts/d.yaml
+++ b/800.renames-and-merges/fonts/d.yaml
@@ -72,6 +72,7 @@
     - fonts-ttf-droid
     - fonts-ttf-google-droid
     - google-droid-fonts
+    - media-fonts/droid
 
 - setname: "fonts:dustin-dustismo"
   name:


### PR DESCRIPTION
Used by Funtoo, Gentoo, HaikuPorts and LiGurOS: https://repology.org/project/droid/versions.