### PR TITLE
fonts:jetbrains-mono add more packages

### DIFF
--- a/800.renames-and-merges/fonts/j.yaml
+++ b/800.renames-and-merges/fonts/j.yaml
@@ -4,6 +4,10 @@
   name:
     - jetbrains-mono
     - ttf-jetbrains-mono
+    - jetbrainsmono
+    - jetbrains-mono-fonts
+    - font-jetbrainsmono-ttf
+    - font-jetbrains-mono
 
 - setname: "fonts:jisx0213"
   name:

--- a/800.renames-and-merges/fonts/j.yaml
+++ b/800.renames-and-merges/fonts/j.yaml
@@ -2,12 +2,12 @@
 
 - setname: "fonts:jetbrains-mono"
   name:
-    - jetbrains-mono
-    - ttf-jetbrains-mono
-    - jetbrainsmono
-    - jetbrains-mono-fonts
-    - font-jetbrainsmono-ttf
     - font-jetbrains-mono
+    - font-jetbrainsmono-ttf
+    - jetbrains-mono
+    - jetbrains-mono-fonts
+    - jetbrainsmono
+    - ttf-jetbrains-mono
 
 - setname: "fonts:jisx0213"
   name:


### PR DESCRIPTION
Add a few more fonts to the jetbrains-mono group
[jetbrainsmono](https://repology.org/project/jetbrainsmono/versions) used by Chocolaty, nixpkgs and SlackBuilds
[jetbrains-mono-fonts](https://repology.org/project/jetbrains-mono-fonts/versions) used by Fedora
[font-jetbrainsmono-ttf](https://repology.org/project/font-jetbrainsmono-ttf/versions) used by Solus 
[font-jetbrains-mono](https://repology.org/project/font-jetbrains-mono/versions) used by GNU Guix