### PR TITLE
KDE Step was renamed to step-physical-simulator

### DIFF
--- a/900.version-fixes/s.yaml
+++ b/900.version-fixes/s.yaml
@@ -235,7 +235,7 @@
 - { name: sslwrap,                     verpat: "[0-9]{3}",                                 incorrect: true } # 2.0.6, not 206
 - { name: ssmtp,                       vergt: "2.64",                                      successor: true } # https://github.com/solbu/ssmtp
 - { name: steamcmd,                                                                        noscheme: true }
-- { name: step,                        verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
+- { name: step-physical-simulator,     verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
 - { name: stepmania,                   verpat: ".*b.*",                                    devel: true }
 - { name: sterm,                       verpat: "20[0-9]{6}",                               snapshot: true }
 - { name: stlink,                      verpat: "20[0-9]{2}.*",                             ignore: true } # snapshot


### PR DESCRIPTION
The devel marking for in-development versions wasn't changed when Step was renamed.  This commit fixes that.