### PR TITLE
et ambiguity: eggtimer's new upstream wwwpart

### DIFF
--- a/850.split-ambiguities/e.yaml
+++ b/850.split-ambiguities/e.yaml
@@ -99,7 +99,7 @@
 - { name: espresso, warning: "please classify me" }
 
 - { name: et, wwwpart: mistertea, setname: eternalterminal }
-- { name: et, wwwpart: geistesk, setname: eggtimer }
+- { name: et, wwwpart: [geistesk,oxzi], setname: eggtimer }
 - { name: et, category: games, setname: enemy-territory }
 - { name: et, ruleset: solus, setname: eternalterminal }
 - { name: et, warning: "please classify me" }


### PR DESCRIPTION
The upstream repository for `eggtimer`, part of the ambiguous `et` package, has changed.