### PR TITLE
Add split for rmtrash

### DIFF
--- a/850.split-ambiguities/r.yaml
+++ b/850.split-ambiguities/r.yaml
@@ -59,6 +59,10 @@
 - { name: ricochet, ruleset: solus, setname: ricochet-im }
 - { name: ricochet, addflag: unclassified }
 
+- { name: rmtrash, wwwpart: nightproductions, setname: rmtrash-nightproductions }
+- { name: rmtrash, wwwpart: PhrozenByte, setname: rmtrash-phrozenbyte }
+- { name: rmtrash, addflag: unclassified }
+
 - { name: rocks, wwwpart: rocksndiamonds, setname: rocksndiamonds } # XXX: problem
 
 - { name: rootsh, ruleset: maemo, setname: rootsh-maemo }


### PR DESCRIPTION
The [macOS software](http://www.nightproductions.net/cli.htm) included in Homebrew and MacPorts is different from the [Linux one](https://github.com/PhrozenByte/rmtrash).

Note that this is similar to the split of `trash` done in 57b334d. @AMDmi3 I wonder if these two should have the suffix `-macos` instead of `-osx`; WDYT?