### PR TITLE
split gf

### DIFF
--- a/850.split-ambiguities/g.yaml
+++ b/850.split-ambiguities/g.yaml
@@ -33,6 +33,9 @@
 - { name: getopt, wwwpart: util-linux, setname: util-linux }
 - { name: getopt, wwwpart: ossp, setname: ossp-getopt }
 
+- { name: gf, wwwpart: gamedevframework, setname: gamedev-framework }
+- { name: gf, wwwpart: grammaticalframework, setname: grammatical-framework }
+
 - { name: ghostscript-fonts, wwwpart: gs-fonts, setname: ghostscript-fonts-std }
 
 - { name: gimme, wwwpart: travis-ci/gimme, setname: gimme-go }

--- a/850.split-ambiguities/g.yaml
+++ b/850.split-ambiguities/g.yaml
@@ -35,6 +35,7 @@
 
 - { name: gf, wwwpart: gamedevframework, setname: gamedev-framework }
 - { name: gf, wwwpart: grammaticalframework, setname: grammatical-framework }
+- { name: gf, addflag: unclassified }
 
 - { name: ghostscript-fonts, wwwpart: gs-fonts, setname: ghostscript-fonts-std }
 


### PR DESCRIPTION
`gamedev-framework` and `grammatical-framework` both use `gf` as their package name in different repositories. The problem has already been reported [here](https://repology.org/project/gf/report).

In order to be fair, I did not kept the `gf` name for either, I made the names more explicit for both (and `gamedev-framework` already exists in vcpkg and in [repology](https://repology.org/project/gamedev-framework/versions) too).
