### PR TITLE
Merge all names for generaluser soundfont

### DIFF
--- a/800.renames-and-merges/g.yaml
+++ b/800.renames-and-merges/g.yaml
@@ -65,6 +65,7 @@
 - { setname: gegl,                     name: gegl-unstable, ignore: true }
 - { setname: geki2,                    name: geki2-kxl, ruleset: gentoo } # XXX: recheck
 - { setname: geki3,                    name: geki3-kxl, ruleset: gentoo } # XXX: recheck
+- { setname: generaluser-soundfont,    name: [generaluser-gs-soundfont,generaluser,generaluser-gs,gusersoundfont,soundfont-generaluser] }
 - { setname: generator-scripting-language, name: gsl-ucg }
 - { setname: genpuid,                  name: linux-genpuid, ruleset: freebsd }
 - { setname: gens,                     name: gensemulator }


### PR DESCRIPTION
Every name has exactly 1 entry. Using name generaluser-soundfont,
because the only soundfont package with similarly merged names is
fluid-soundfont.