### PR TITLE
Merge the various 'premake's

### DIFF
--- a/800.renames-and-merges/p.yaml
+++ b/800.renames-and-merges/p.yaml
@@ -209,6 +209,7 @@
 - { setname: ppsspp,                   name: ppsspp-devel, weak_devel: true }
 - { setname: ppsspp,                   name: ppsspp-qt5-devel, addflavor: qt5, weak_devel: true }
 - { setname: pptpd,                    name: [bcrelay,poptop,poptop-man,pptpd-server], addflavor: true }
+- { setname: premake,                  name: [premake3,premake4,premake5] }
 - { setname: presto,                   name: presto-cli }
 - { setname: printproto,               name: xprintproto }
 - { setname: privoxy,                  name: freedombox-privoxy, addflavor: true }


### PR DESCRIPTION
This PR combines the projects `premake3`, `premake4`, and `premake5` into the larger `premake`, as they are arguably the same project.

`namepat` could be used instead to identify the packages, but I recall you've stated before that patterns are somewhat expensive.