### PR TITLE
Ignore xview versions other than 3.2p1.4

### DIFF
--- a/900.version-fixes/x.yaml
+++ b/900.version-fixes/x.yaml
@@ -145,6 +145,7 @@
 - { name: xtitle,                      ver: "20170206",                                    outdated: true } # 0.4.3 which is latest normal version ls from feb 15, e.g. newer
 - { name: xtreemfs,                    verlonger: 3,                 ruleset: nix,         incorrect: true }
 - { name: xtrlock-pam,                 verpat: ".*post.*",                                 snapshot: true }
+- { name: xview,                       notver: "3.2p1.4",                                  ignore: true } # only accept version 3.2p1.4
 - { name: xwinwrap-shantz,                                                                 noscheme: true }
 - { name: xxdiff,                      verpat: ".*20[0-9]{6}",                             snapshot: true }
 - { name: xxdiff,                      verpat: "[0-9]{3}",                                 incorrect: true }


### PR DESCRIPTION
Only accept the xview version number for the final (circa 1997?) upstream version of xview.  Other varations on this version number indicate the downstream patch level.