### PR TITLE
899..global: match gentoo snapshot patch releases as ignore

### DIFF
--- a/899.version-fixes.global.yaml
+++ b/899.version-fixes.global.yaml
@@ -59,6 +59,7 @@
 - { verpat: ".*r.*", namepat: "php:.*",                              ruleset: freebsd,     devel: true }
 - { verpat: "5\\.[0-9]{2}\\.0",                                      ruleset: kaos_build,  untrusted: true } # accused of faking -rc versions of KDE stuff as release
 - { verpat: "[0-9.]+_git.+",                                         ruleset: alpine,      ignore: true } # snapshots
+- { verpat: ".*_p20[0-9]{6}",                                        ruleset: gentoo,      ignore: true } # snapshots
 
 # nuget is terminally broken and can't handle arbitrary version schemes, so most are garbage
 - {                                                                  ruleset: chocolatey,  untrusted: true }


### PR DESCRIPTION
Matches versions such as `1.0_p20200130` which are actually snapshots post release
Does not match versions such as `11.0.9_p11` which are normal patch releases

https://regex101.com/r/adXgXl/2