### PR TITLE
Add rule for SReview

### DIFF
--- a/800.renames-and-merges/s.yaml
+++ b/800.renames-and-merges/s.yaml
@@ -244,6 +244,7 @@
 - { setname: squirrel-sql,             name: squirrelsqlstandard, addflavor: standard }
 - { setname: squirrelmail-$1,          namepat: "squirrelmail-(.*)-plugin", ruleset: freebsd }
 - { setname: sratom,                   name: libsratom }
+- { setname: sreview,                  name: "perl:sreview" }
 - { setname: ssmtp,                    name: ssmtp-plain, addflavor: plain }
 - { setname: sssd,                     name: sssd-nosmb, addflavor: true }
 - { setname: ssvnc,                    name: [ssvnc-nojava,ssvnc-viewer], addflavor: true }


### PR DESCRIPTION
SReview is packaged on CPAN as SReview, and in Debian as sreview (not libsreview-perl, as it's a program, not a library)

Note though that perl:sreview doesn't currently show up on repology.org. I don't know whether that's a separate thing that needs to be taken care of, or whether it's expected and will resolve itself...?