### PR TITLE
Rename rage-encryption-tool to rage-encryption

### DIFF
--- a/850.split-ambiguities/r.yaml
+++ b/850.split-ambiguities/r.yaml
@@ -4,7 +4,7 @@
 - { name: racer, setname: "rust:racer" }
 
 - { name: rage, wwwpart: enlightenment, setname: rage-mediacenter }
-- { name: rage, wwwpart: str4d, setname: rage-encryption-tool }
+- { name: rage, wwwpart: str4d, setname: rage-encryption }
 - { name: rage, addflag: unclassified }
 
 - { name: range, wwwpart: range-v3, setname: range-v3 }


### PR DESCRIPTION
This brings it in line with `age-encryption` in `850.split-ambiguities/a.yaml`, which is the Go implementation of the same tool;

https://github.com/repology/repology-rules/blob/80c0d06b86b8283ec05188530afdd9c6617919f9/850.split-ambiguities/a.yaml#L35