### PR TITLE
ntfs-3g: normalize the incorrect AR scheme to AR

### DIFF
--- a/900.version-fixes/n.yaml
+++ b/900.version-fixes/n.yaml
@@ -103,7 +103,7 @@
 - { name: nrg2iso,                     ver: "0.5",                   ruleset: opensuse,    incorrect: true }
 - { name: nrg2iso,                                                   ruleset: opensuse,    untrusted: true } # accused of fake 0.5
 - { name: nss-ldap,                    verpat: "1\\.([0-9]{3,})",                          setver: "$1" } # FreeBSD garbage
-- { name: ntfs-3g,                     verpat: "(\\.[0-9]+){3}(\\.[0-9]+)",                setver: "$1AR$2" } # incorrect scheme for ARs
+- { name: ntfs-3g,                     verpat: "(\\.[0-9]+\\.[0-9]+\\.[0-9]+)(\\.[0-9]+)",                setver: "$1AR$2" } # incorrect scheme for ARs
 - { name: ntfs-3g,                     verpat: ".*ar.*",                                   any_is_patch: true, devel: true } # http://jp-andre.pagesperso-orange.fr/advanced-ntfs-3g.html
 - { name: ntp,                         verpat: "([0-9]+\\.[0-9]+\\.[0-9]+)\\.([0-9]+)",    setver: "$1p$2" }
 - { name: ntp,                                                                             p_is_patch: true }

--- a/900.version-fixes/n.yaml
+++ b/900.version-fixes/n.yaml
@@ -103,8 +103,8 @@
 - { name: nrg2iso,                     ver: "0.5",                   ruleset: opensuse,    incorrect: true }
 - { name: nrg2iso,                                                   ruleset: opensuse,    untrusted: true } # accused of fake 0.5
 - { name: nss-ldap,                    verpat: "1\\.([0-9]{3,})",                          setver: "$1" } # FreeBSD garbage
+- { name: ntfs-3g,                     verpat: "(\\.[0-9]+){3}(\\.[0-9]+)",                setver: "$1AR$2" } # incorrect scheme for ARs
 - { name: ntfs-3g,                     verpat: ".*ar.*",                                   any_is_patch: true, devel: true } # http://jp-andre.pagesperso-orange.fr/advanced-ntfs-3g.html
-- { name: ntfs-3g,                     verpat: "[0-9]+(\\.[0-9]+){3}",                     incorrect: true } # incorrect scheme for ARs
 - { name: ntp,                         verpat: "([0-9]+\\.[0-9]+\\.[0-9]+)\\.([0-9]+)",    setver: "$1p$2" }
 - { name: ntp,                                                                             p_is_patch: true }
 - { name: nuget,                       vercomps: 4,                                        altver: true }


### PR DESCRIPTION
It feels a bit more useful to just normalize the scheme instead of marking it as wrong.