### PR TITLE
Don't mark latest clojure version as incorrect

### DIFF
--- a/900.version-fixes/c.yaml
+++ b/900.version-fixes/c.yaml
@@ -152,7 +152,7 @@
 - { name: clisp,                       ver: "2.50",                                        untrusted: true } # very likely fake, see reports
 - { name: clisp,                       vereq: "2.49.93",             ruleset: [arch,freebsd,fedora,manjaro,ravenports], incorrect: true }
 - { name: clisp,                                                     ruleset: [arch,freebsd,fedora,manjaro,ravenports], untrusted: true } # accused of fake 2.49.93
-- { name: clojure,                     verpat: "[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]{3,}",     incorrect: true } # homebrew and nix garbage
+- { name: clojure,                     verpat: "[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]{3,}",     altver: true } # extra deps version appended by upstream
 - { name: clonekeen,                   verpat: "0\\.(.*)",                                 setver: "$1" }
 - { name: cloog,                       ver: "0.18.5",                ruleset: [haikuports, aosc, arch], ignore: true } # unofficial fork
 - { name: cloudfuse,                   verpat: "20[0-9]{6}",                               snapshot: true }


### PR DESCRIPTION
Latest clojure version (`1.10.3.814`) is marked as incorrect, but that's
the latest released version. Official clojure changelog can be found
here:
https://github.com/clojure/brew-install/blob/1.10.3/CHANGELOG.md

There is an official download for `1.10.3.814`:
https://download.clojure.org/install/linux-install-1.10.3.814.sh

But not for `1.10.3`:
https://download.clojure.org/install/linux-install-1.10.3.sh

Before `1.9.0`, clojure versions followed this pattern: `x.y.z`, but since
`1.9.0`, the pattern is `x.y.z.nnn`.