### PR TITLE
Merge names for libmt32emu

### DIFF
--- a/800.renames-and-merges/m.yaml
+++ b/800.renames-and-merges/m.yaml
@@ -244,6 +244,7 @@
 - { setname: msgpack,                  name: [msgpack-c,msgpack-c-cpp,libmsgpack,msgpack1] } # c/cpp by default
 - { setname: mstflint,                 name: mstflint4 }
 - { setname: msynctool,                namepat: "msynctool[0-9]+" }
+- { setname: mt32emu,                  name: [libmt32emu, munt-mt32emu] }
 - { setname: mtdev,                    name: libmtdev }
 - { setname: mtxclient,                name: libmtxclient }
 - { setname: mullvad-vpn,              name: [mullvad-app, mullvad] }


### PR DESCRIPTION
Repository packagers are confused, as the lib lives within the repo of
the munt project.