### PR TITLE
ignore versions in centos

### DIFF
--- a/900.version-fixes/v.yaml
+++ b/900.version-fixes/v.yaml
@@ -40,6 +40,7 @@
 - { name: vim-airline-themes,                                                              noscheme: true }
 - { name: "vim:vim-flake8",            verpat: "20[0-9]{2}.*",                             snapshot: true }
 - { name: vimpc,                       verpat: ".*20[0-9]{6}.*",                           snapshot: true }
+- { name: virtio-win,                                                ruleset: rpm,         ignore: true } # uses incorrect versioning scheme
 - { name: virtme,                      verpat: ".*20[0-9]{6}",                             snapshot: true }
 - { name: virtualbox,                  verpat: ".*[0-9]{6}.*",                             incorrect: true }
 - { name: virtualbox,                  verpat: ".*-.*",              ruleset: nix,         incorrect: true } # kernel version appended


### PR DESCRIPTION
Signed-off-by: Aisha Tammy <floss@bsd.ac>

---

the versions in centos and rosa server are using a different versioning scheme from upstream