### PR TITLE
split oh-my to oh-my-git (bash/zsh prompt) and oh-my-git-game (Git learning game)

### DIFF
--- a/850.split-ambiguities/o.yaml
+++ b/850.split-ambiguities/o.yaml
@@ -94,3 +94,6 @@
 - { name: otter, wwwpart: [ar/otter,mccune], setname: otter-prover }
 - { name: otter, ver: "3.3f", setname: otter-prover } # circa 2004, unlikely to change
 - { name: otter, addflag: unclassified }
+
+- { name: oh-my, wwwpart: [ohmygit.org, github.com/git-learning-game/oh-my-git], setname: oh-my-git-game }
+- { name: oh-my, wwwpart: [github.com/arialdomartini/oh-my-git], setname: oh-my-git }


### PR DESCRIPTION
Hey,

i am the maintainer of the Git learning game "Oh My Git!" (https://ohmygit.org/ resp. https://github.com/git-learning-game/oh-my-git) on NixOS/nixpkgs.

There already exists a bash/zsh-prompt called "oh-my-git" (https://github.com/arialdomartini/oh-my-git) which is listed together with the game under the project "oh-my" (https://repology.org/project/oh-my/packages).

I therefore renamed the prompt to "oh-my-git" and the game to "oh-my-git-game". I hope that's appropriate.