### PR TITLE
Disambiguate mcedit-unified

### DIFF
--- a/850.split-ambiguities/m.yaml
+++ b/850.split-ambiguities/m.yaml
@@ -54,6 +54,9 @@
 - { name: mc, wwwpart: minio, setname: minio-mc }
 - { name: mc, wwwpart: fetk, setname: mc-manifold-code }
 
+- { name: mcedit, wwwpart: mcedit-unified, setname: mcedit-unified }
+- { name: mcedit, addflag: unclassified }
+
 - { name: mcs, wwwpart: go-mono, setname: mcs-mono-compiler }
 - { name: mcs, wwwpart: [atheme,nenolod], setname: mcs-modular-config-system }
 - { name: mcs, addflag: unclassified }


### PR DESCRIPTION
There are currently two packages titled simply [mcedit](https://repology.org/project/mcedit), which should be merged into [mcedit-unified](https://repology.org/project/mcedit-unified).

Not sure if the fact that there will be two AUR packages named `mcedit-unified` will be an issue; both _do_ correspond to the same project:

- https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=mcedit-git
- https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=mcedit-unified