### PR TITLE
unison: update version rules

### DIFF
--- a/800.renames-and-merges/u.yaml
+++ b/800.renames-and-merges/u.yaml
@@ -38,7 +38,7 @@
 - { setname: unigine-heaven,           name: linux-unigine-heaven, ruleset: freebsd }
 - { setname: unigine-valley,           name: linux-unigine-valley, ruleset: freebsd }
 - { setname: unison,                   name: unison-devel, weak_devel: true, nolegacy: true }
-- { setname: unison,                   namepat: "unison([0-9.-]*)(?:-compat)?" }
+- { setname: unison,                   namepat: "unison([0-9.+-]*)(?:-compat)?" }
 - { setname: unit,                     name: [nginx-unit, nginx-unitd] }
 - { setname: unit,                     namepat: "(?:nginx-)?unit-((?:go|php|python|perl)[0-9.-]*)", addflavor: $1 }
 - { setname: units,                    name: [gnu-units,gunits] }

--- a/900.version-fixes/u.yaml
+++ b/900.version-fixes/u.yaml
@@ -40,7 +40,7 @@
 - { name: unfs3,                                                     ruleset: openwrt,     untrusted: true } # entware
 - { name: unicode-ucd,                 verpat: "(.*)\\+.*",                                setver: "$1" } # aosc snapshot
 - { name: uniconvertor,                ver: "2.0",                   ruleset: rpm,         incorrect: true } # not yet released
-- { name: unison,                      verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true } # XXX: assumed, not confirmed; http://www.cis.upenn.edu/~bcpierce/unison/download.html
+- { name: unison,                      verpat: "([0-9]+\\.){3}[789][0-9]+",                devel: true } # 2.51.3.72
 - { name: unit,                        ver: "1.7.1",                 ruleset: openpkg,     incorrect: true }
 - { name: unit,                                                      ruleset: openpkg,     untrusted: true } # accused of fake 1.7.1
 - { name: universal-ctags,                                                                 noscheme: true }


### PR DESCRIPTION
Merge names with embedded OCaml version, such as https://repology.org/project/unison-2.51%2B4.11.1/versions
Odd minor versions are not Unison devel versions.