### PR TITLE
Merge xone

### DIFF
--- a/800.renames-and-merges/x.yaml
+++ b/800.renames-and-merges/x.yaml
@@ -82,6 +82,7 @@
 - { setname: xmonad,                   name: "haskell:xmonad" }
 - { setname: xmoto,                    name: x-moto }
 - { setname: xmrig,                    name: xmrig-donateless, addflavor: donateless }
+- { setname: xone,                     name: xone-dkms }
 - { setname: xonotic,                  name: [xonotic-data,xonotic-data-low], addflavor: true }
 - { setname: xorriso,                  name: xorisso } # gobolinux typo, XXX: problem
 - { setname: xosd,                     name: libxosd }


### PR DESCRIPTION
Merge `xone` with `xone-dkms`, which is the name we use in the AUR: https://aur.archlinux.org/packages/xone-dkms-git/