### PR TITLE
Add devel rule for darling-dmg

### DIFF
--- a/900.version-fixes/d.yaml
+++ b/900.version-fixes/d.yaml
@@ -12,6 +12,7 @@
 - { name: darkplaces,                                                ruleset: pclinuxos,   untrusted: true } # accused of fake 20141016
 - { name: darktable,                   verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
 - { name: darktable,                   ver: "2.6.3.1",                                     setver: "2.6.3" } # mac osx dedicated rerelease
+- { name: darling-dmg,                 verpat: ".*git20[0-9]{6}",    ruleset: nix,         devel: true }
 - { name: dasher,                      verpat: ".*20[0-9]{6}.*",                           snapshot: true }
 - { name: dasher,                      verpat: "20[0-9]{2}.*",                             incorrect: true }
 - { name: dbus,                        verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }


### PR DESCRIPTION
The version of darling-dmg in Nixpkgs currently has the version 1.0.4+git20200427, which is using a git revision without a corresponding git tag from the upstream repo, so mark it as a development version.

FYI: this is my first contribution to this repo.