### PR TITLE
Ignore snapshot release of an ucarp fork

### DIFF
--- a/900.version-fixes/u.yaml
+++ b/900.version-fixes/u.yaml
@@ -9,6 +9,7 @@
 - { name: ubertooth,                                                                       any_is_patch: true } # 2020.12.R1
 - { name: uberwriter,                  verpat: "[0-9]{2}(\\.[0-9]{2}){2}",                 incorrect: true } # void
 - { name: ubi-reader,                  verpat: "20[0-9]{6}",                               snapshot: true }
+- { name: ucarp,                       verpat: ".+20[0-9]{6}",                             ignore: true } # snapshot release from an unmaintained fork
 - { name: ucspi-ssl,                   ver: "0.999.10.11",                                 setver: "0.10.11", disposable: true } # XXX: exists only because and as long as it conveys a new version
 - { name: ucspi-ssl,                   verpat: "0\\.999.*",                                incorrect: true }
 - { name: ucspi-ssl,                   relge: "0.60", verle: "0.99z",                      outdated: true } # 0.9x < 0.10.x


### PR DESCRIPTION
There is an unmaintained ucarp fork out there, from which a snapshot release is used by DPorts and FreeBSD Ports. This change ignores this version.