### PR TITLE
Add noscheme for apfsprogs

### DIFF
--- a/900.version-fixes/a.yaml
+++ b/900.version-fixes/a.yaml
@@ -142,6 +142,7 @@
 - { name: aom,                         verpat: ".*20[0-9]{6}",                             snapshot: true }
 - { name: apache,                      verpat: "2\\.[0-9]*[13579]\\..*",                   devel: true }
 - { name: apel,                        verpat: ".*20[0-9]{6}",                             snapshot: true }
+- { name: apfsprogs,                                                                       noscheme: true } # no tags, binaries and man pages show 0.1 as a "version"
 - { name: apidb,                       ver: "5.0.0",                 ruleset: aur,         incorrect: true }
 - { name: apidb,                                                     ruleset: aur,         untrusted: true } # accused of fake 5.0.0
 - { name: apiextractor,                ver: "0.10.11",               ruleset: sisyphus,    incorrect: true }


### PR DESCRIPTION
There are no official releases, git tags or similar. `apfsck -v` and `mkapfs -v` print 0.1 as the version and the man pages also show 0.1 but this has been the case since at least 2019: https://github.com/linux-apfs/apfsprogs/commit/db9d5f312fb59dbac118dad948ed5df6c0a9b6ce. According to the commit message "We've been using '0.1' in the man pages for while, so continue with that number until we reach an actual release.".