### PR TITLE
Distinct between Claws Mail version three and four

### DIFF
--- a/950.split-branches.yaml
+++ b/950.split-branches.yaml
@@ -45,6 +45,8 @@
 
 - { name: clanlib,                                        setbranchcomps: 1 }
 
+- { name: claws-mail,                                     setbranchcomps: 1 }
+
 - { name: clutter-gst,                                    setbranchcomps: 1 }
 
 - { name: compiz,                                         setbranchcomps: 2 }


### PR DESCRIPTION
With its latest release[0], Claws Mail has two versions, 3.18.0 and
4.0.0. The major version three release branch continues depending on
GTK+ 2, while major version four uses GTK+ 3 instead.

This commit separates those two releases by renaming the now older one,
major version three, to claws-mail-gtk2, as it is expected to become
deprecated on the long run.

[0] https://claws-mail.org/NEWS