### PR TITLE
Merge qdarkstyle

### DIFF
--- a/800.renames-and-merges/python.yaml
+++ b/800.renames-and-merges/python.yaml
@@ -320,6 +320,7 @@
 - { setname: "python:pyxdg",           name: pyxdg }
 - { setname: "python:pyyaml",          name: [pypy-yaml,pypy3-yaml], addflavor: pypy } # XXX: global rule for pypy-*?
 - { setname: "python:pyyaml",          name: [pyyaml,"python:yaml"] }
+- { setname: "python:qdarkstyle",      name: qdarkstyle }
 - { setname: "python:qt.py",           name: "python:qt-py" }
 - { setname: "python:rabbyt",          name: rabbyt }
 - { setname: "python:rawkit",          name: rawkit }


### PR DESCRIPTION
The Arch package for `python:qdarkstyle` and the Debian Testing package for `qdarkstyle` both list https://github.com/ColinDuquesnoy/QDarkStyleSheet as upstream.