### PR TITLE
Merge aiorpcx

### DIFF
--- a/800.renames-and-merges/python.yaml
+++ b/800.renames-and-merges/python.yaml
@@ -8,6 +8,7 @@
 - { setname: "python:aiohttp-cors",    name: "python:aiohttp-cors-gns3", addflavor: true }
 - { setname: "python:aiohttp-jinja2",  name: ["python:aiohttp-jinja"] } # XXX: problem
 - { setname: "python:aiopg",           name: aiopg }
+- { setname: "python:aiorpcx",         name: aiorpcx }
 - { setname: "python:aiozmq",          name: aiozmq }
 - { setname: "python:airnef",          name: airnef }
 - { setname: "python:aplpy",           name: aplpy }


### PR DESCRIPTION
The Arch package for `python:aiorpcx` and the Debian Testing package for `aiorpcx` both list https://github.com/kyuupichan/aiorpcX/ as upstream.