### PR TITLE
Merge fs-repo-migrations

### DIFF
--- a/800.renames-and-merges/f.yaml
+++ b/800.renames-and-merges/f.yaml
@@ -166,6 +166,7 @@
 - { setname: frozen-bubble,            name: frozenbubble2 }
 - { setname: frr,                      namepat: "frr[0-9.-]+" }
 - { setname: frr,                      name: frrouting }
+- { setname: fs-repo-migrations,       name: [ipfs-migrator, ipfs-go-fs-repo-migrations] }
 - { setname: fs-uae,                   name: [fs-uae-devel, fs-uae-dev], weak_devel: true, nolegacy: true }
 - { setname: fs-uae-arcade,            name: [fs-uae-arcade-devel, fs-uae-arcade-dev], weak_devel: true, nolegacy: true }
 - { setname: fs-uae-launcher,          name: [fs-uae-launcher-devel, fs-uae-launcher-dev], weak_devel: true, nolegacy: true }


### PR DESCRIPTION
fs-repo-migrations is the actual name: https://github.com/ipfs/fs-repo-migrations.
It is called [ipfs-migrator](https://repology.org/project/ipfs-migrator/versions) in Nixpkgs and [ipfs-go-fs-repo-migrations](
https://repology.org/project/ipfs-go-fs-repo-migrations/versions) in FreeBSD Ports.