### PR TITLE
Split ansible

### DIFF
--- a/800.renames-and-merges/a.yaml
+++ b/800.renames-and-merges/a.yaml
@@ -127,8 +127,8 @@
 - { setname: anki,                     name: [anki12,anki20,"python:anki2"] }
 - { setname: annex,                    name: annex-conquer-the-world }
 - { setname: ansible,                  namepat: "(?:python:)?ansible[0-9]*" }
-- { setname: ansible,                  name: [ansible-base, "python:ansible-base" ] } # XXX: there's a mess in ansible releases (ansible vs. core vs. base and 2.x vs 3.x)
-- { setname: ansible,                  name: [ansible-core, "python:ansible-core" ] } # would be nice of someone with knowledge to sort this out
+- { setname: ansible-core,             name: ansible, ruleset: [openpkg, solus] }
+- { setname: ansible-core,             name: [ansible-base, "python:ansible-base"] }
 - { setname: ansible-lint,             name: "python:ansible-lint" }
 - { setname: ansible-runner,           name: "python:ansible-runner" }
 - { setname: ant,                      name: ant-junit5, addflavor: true }

--- a/950.split-branches.yaml
+++ b/950.split-branches.yaml
@@ -2,9 +2,6 @@
 
 - { name: allegro,           verlt: "4.9",                setname: allegro4 }
 
-- { name: ansible,           verge: "3",                  setname: ansible-collections }
-- { name: ansible,           verlt: "3",                  setbranchcomps: 2 }
-
 - { name: antlr,                                          setbranchcomps: 1 }
 
 - { name: apache,                                         setbranchcomps: 2 }


### PR DESCRIPTION
I made a comment at https://repology.org/project/ansible/report, but I suppose it's barely understandable, so I figured I would upload code explaining what I mean. I don't know if that works, the intent is to make:

- Packages called `ansible-base` or `ansible-core` should be put into `ansible-core`.
- Packages called `ansible` from OpenPKG, Solus, Wikidata should be put into `ansible-core` because they actually package `ansible-core` (well, okay, Wikidata doesn't package anything, but still, they have `ansible-core` version, not `ansible` version).