### PR TITLE
Merge zram-generator into rs:zram-generator

### DIFF
--- a/800.renames-and-merges/z.yaml
+++ b/800.renames-and-merges/z.yaml
@@ -43,6 +43,7 @@
 - { setname: zork,                     name: [zork1,zork2,zork3] }
 - { setname: zou,                      name: "rust:zou" }
 - { setname: zoxide,                   name: "rust:zoxide" }
+- { setname: zram-generator,           name: "rust:zram-generator" }
 - { setname: zsa-wally-cli,            name: wally-cli }
 - { setname: zsh,                      name: [zsh-doc,zsh-minimal], addflavor: true }
 - { setname: zsh,                      name: zsh-beta, weak_devel: true, nolegacy: true }


### PR DESCRIPTION
E.g. Fedora has rust-zram-generator as the source package name,
but the binary package is zram-generator… Similar confusion happens
in other places.