### PR TITLE
Merge firmware-iscan into iscan-firmware

### DIFF
--- a/800.renames-and-merges/i.yaml
+++ b/800.renames-and-merges/i.yaml
@@ -106,6 +106,7 @@
 - { setname: irrlicht,                 name: libirrlicht }
 - { setname: irssi-otr,                name: irssi-plugin-otr }
 - { setname: irssi-otr,                name: irc-otr } # XXX: problem
+- { setname: iscan-firmware,           name: firmware-iscan }
 - { setname: isl,                      namepat: "(?:lib)?isl[0-9.-]*" }
 - { setname: iso8879,                  name: iso-8879 }
 - { setname: ispell-uk,                name: aspell-uk, ver: ["1.6.5","1.8.0"] } # see ftp://ftp.gnu.org/gnu/aspell/dict/uk/


### PR DESCRIPTION
firmware-iscan is only used by ALT Linux