### PR TITLE
vala-lint noscheme

### DIFF
--- a/900.version-fixes/v.yaml
+++ b/900.version-fixes/v.yaml
@@ -7,6 +7,7 @@
 - { name: vacuum-im,                   ver: "1.3.0",                 ruleset: opensuse,    incorrect: true }
 - { name: vacuum-im,                                                 ruleset: opensuse,    untrusted: true } # accused of fake 1.3.0
 - { name: vala,                        verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
+- { name: vala-lint,                                                                       noscheme: true }
 - { name: valentina,                   verpat: ".*a",                                      devel: true }
 - { name: vapoursynth,                 verpat: "R([.0-9]+)",                               setver: "$1" }
 - { name: "vapoursynth:fmtconv",       verpat: "[0-9]+",                                   setver: r$0 }


### PR DESCRIPTION
There are no versions for vala-lint

https://github.com/vala-lang/vala-lint

https://repology.org/project/vala-lint/versions