### PR TITLE
Fix python:pypcap version by excluding AUR release

### DIFF
--- a/900.version-fixes/python.yaml
+++ b/900.version-fixes/python.yaml
@@ -103,6 +103,7 @@
 - { name: "python:pymaging-png",                                                           noscheme: true }
 - { name: "python:pyode",              verpat: ".*2010.*",                                 ignore: true }
 - { name: "python:pyparsing",          verpat: ".*test.*",           ruleset: opensuse,    incorrect: true } # fake
+- { name: "python:pypcap",             verlonger: 3,                 ruleset: aur,         incorrect: true } # fake release with custom patch
 - { name: "python:pyqrcode",           ver: "1.3.0",                 ruleset: opensuse,    incorrect: true } # different package
 - { name: "python:pyqrcode",                                         ruleset: opensuse,    untrusted: true } # accused of faking pyqrcodeng as pyqrcode
 - { name: "python:pyqt5",              ver: "5.15.2",                ruleset: blackarch,   incorrect: true } # 5.15.2.dev2009281246 in fact


### PR DESCRIPTION
The AUR version of the Python pypcap package is a custom fork, only used
within the AUR. This fork is only one patch ahead of the other version
and is not an "official" release.