### PR TITLE
MLdonkey naming

### DIFF
--- a/800.renames-and-merges/m.yaml
+++ b/800.renames-and-merges/m.yaml
@@ -186,6 +186,7 @@
 - { setname: mixxx,                    name: mixxx-qt5, addflavor: true }
 - { setname: mkcert,                   name: "go:mkcert", addflavor: true }
 - { setname: mksh,                     name: mksh-static, addflavor: true }
+- { setname: mldonkey,                 name: [mldonkey-core,mldonkey-gui,mldonkey-ed2kad-daemon], addflavor: true }
 - { setname: mlt,                      name: [libmlt, mlt-qt4, mlt-qt5,mlt-freeworld,"python:mlt"], addflavor: true }
 - { setname: mmtc,                     name: "rust:mmtc" }
 - { setname: mmtf-cpp,                 name: libmmtf }


### PR DESCRIPTION
mldonkey is splitted between core and gui for FreeBSD
mldonkey-ed2kad-daemon is a variation on AUR