### PR TITLE
Masterpdfeditor: add alternative name

### DIFF
--- a/800.renames-and-merges/m.yaml
+++ b/800.renames-and-merges/m.yaml
@@ -48,7 +48,7 @@
 - { setname: markets,                  name: bitstower-markets }
 - { setname: marktext,                 name: mark-text }
 - { setname: mash,                     name: libmash }
-- { setname: master-pdf-editor,        name: [masterpdfeditor,masterpdfeditor4,master-pdf-editor5] }
+- { setname: master-pdf-editor,        name: [masterpdfeditor,masterpdfeditor4,master-pdf-editor5,master-pdf-editor5paid] }
 - { setname: master-pdf-editor,        name: masterpdfeditor-free, legacy: true }
 - { setname: master-pdf-editor,        name: masterpdfeditor-qt4, addflavor: qt4 }
 - { setname: master-pdf-editor,        name: masterpdfeditor-libs-included, addflavor: libs-included }


### PR DESCRIPTION
master-pdf-editor5paid name is used in PCLinuxOS