### PR TITLE
kde4-kmldonkey naming

### DIFF
--- a/800.renames-and-merges/k.yaml
+++ b/800.renames-and-merges/k.yaml
@@ -50,6 +50,7 @@
 - { setname: kipi-plugins,             namepat: "kipi-plugin-.*", ruleset: freebsd }
 - { setname: kiwi,                     name: "python:kiwi" } # totally intermixed, split in 850
 - { setname: klotski,                  name: gnome-games-klotski }
+- { setname: kmldonkey,                name: kde4-kmldonkey }
 - { setname: kmon,                     name: "rust:kmon" }
 - { setname: knock,                    name: knockd }
 - { setname: knossos,                  name: knossos4 }


### PR DESCRIPTION
kde4-kmldonkey is the same as kmldonkey

kde4-kmldonkey by PLD Linux likely need to be marked `incorrect`, v2.2.1 don't seem to exist and their .spec file is downloading a date based SVN checkout https://git.pld-linux.org/?p=packages/kde4-kmldonkey.git;a=blob;f=kde4-kmldonkey.spec;h=a72fd7188a4ea0a26a62041b585868b9c48457ef;hb=HEAD

but fìdon't know how to do that

https://repology.org/projects/?search=mldonkey

https://repology.org/project/kde4-kmldonkey/versions