### PR TITLE
Correctly parse Guix VCS snapshots as such

### DIFF
--- a/899.version-fixes.global.yaml
+++ b/899.version-fixes.global.yaml
@@ -69,6 +69,7 @@
 - { verpat: "20[0-9]{2}\\-[0-9]+\\-[0-9]+",                          ruleset: spack,       untrusted: true } # snapshots
 - { verpat: "20[0-9]{2}-[0-9]{2}-[0-9]{2}(?:-unstable)?",            ruleset: nix,         untrusted: true }
 - { verpat: ".+20[0-9]{2}-[0-9]{2}-[0-9]{2}.*",                      ruleset: nix,         ignore: true }
+- { verpat: "(.*)-[0-9]+\\.[0-9a-f]{7}",                             ruleset: guix,        setver: $1, snapshot: true } # snapshots after release $1
 
 # nuget is terminally broken and can't handle arbitrary version schemes, so most are garbage
 - {                                                                  ruleset: chocolatey,  untrusted: true }


### PR DESCRIPTION
This should DTRT if https://github.com/repology/repology-updater/issues/920#issuecomment-931445917 is correct.

Because this was missing there are some buggy `ignore`s scattered across the rule set, which this patch can't fix because the problem isn't technical.