### PR TITLE
bitbake versioning

### DIFF
--- a/900.version-fixes/b.yaml
+++ b/900.version-fixes/b.yaml
@@ -67,8 +67,6 @@
 - { name: bioperl,                     verpat: "[0-9]+\\.[0-9]{2}.*",                      incorrect: true }
 - { name: birdfont,                    verge: "3",                                         ignore: true } # https://birdfont.org/purchase.php (3.x is either different versioning for binary releases, or just not available in source)
 - { name: bison,                       verpat: ".*\\.9[0-9]+",                             devel: true } # https://birdfont.org/purchase.php (3.x is either different versioning for binary releases, or just not available in source)
-- { name: bitbake,                     ver: "1.34",                  ruleset: aur,         incorrect: true }
-- { name: bitbake,                                                   ruleset: aur,         untrusted: true }
 - { name: bitlbee,                     ver: "3.6-1",                                       setver: "3.6" } # no functional changes, debian related stuff
 - { name: bittornado,                  verpat: ".*20[0-9]{6}",                             snapshot: true }
 - { name: bittornado,                  verge: "0.4.0",                                     successor: true } # https://github.com/effigies/BitTornado


### PR DESCRIPTION
AUR pkgbuild have a valid version

https://repology.org/project/bitbake/versions

The last stable bitbake version is 1.52.1 (several stable branch exists, 1.52.x is the latest)

https://git.openembedded.org/bitbake