### PR TITLE
Rename gfold -> rust:gfold

### DIFF
--- a/800.renames-and-merges/g.yaml
+++ b/800.renames-and-merges/g.yaml
@@ -89,6 +89,7 @@
 - { setname: gfbgraph,                 name: libgfbgraph }
 - { setname: gfbgraph,                 namepat: "gfbgraph[0-9.-]+" }
 - { setname: gflags,                   name: [google-gflags,libgflags] }
+- { setname: gfold,                    name: "rust:gfold" }
 - { setname: ghc,                      namepat: "ghc[0-9.-]+" }
 - { setname: ghc,                      name: [ghc-bin,ghc-bootstrap,ghc-libs,ghc-pristine,ghc-raspbian,ghc-static], addflavor: true }
 - { setname: ghc,                      name: haskell, ruleset: scoop }


### PR DESCRIPTION
Fixes a similar issue as https://github.com/repology/repology-rules/issues/558
Closes https://github.com/nickgerace/gfold/issues/160

Thanks for this great project!