### PR TITLE
hide the deprecated 1.24.99 release of hledger*

### DIFF
--- a/900.version-fixes/h.yaml
+++ b/900.version-fixes/h.yaml
@@ -30,6 +30,10 @@
 - { name: hitori,                      ver: "3.24.1",                ruleset: nix,         incorrect: true }
 - { name: hitori,                                                    ruleset: nix,         untrusted: true }
 - { name: hitori,                      verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
+- { name: hledger,                     verpat: ".*\.99\b.*",                               incorrect: true }
+- { name: hledger-lib,                 verpat: ".*\.99\b.*",                               incorrect: true }
+- { name: hledger-ui,                  verpat: ".*\.99\b.*",                               incorrect: true }
+- { name: hledger-web,                 verpat: ".*\.99\b.*",                               incorrect: true }
 - { name: hmmer,                       verpat: ".*b.*",                                    devel: true }
 - { name: hnb,                         ver: [ "1.9.18", "1.9.19" ],                        ignore: true } # unofficial
 - { name: horizon,                     verpat: "20[0-9]{2}\\..*",                          sink: true }

--- a/900.version-fixes/h.yaml
+++ b/900.version-fixes/h.yaml
@@ -30,10 +30,10 @@
 - { name: hitori,                      ver: "3.24.1",                ruleset: nix,         incorrect: true }
 - { name: hitori,                                                    ruleset: nix,         untrusted: true }
 - { name: hitori,                      verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
-- { name: hledger,                     verpat: ".*\.99\b.*",                               incorrect: true }
-- { name: hledger-lib,                 verpat: ".*\.99\b.*",                               incorrect: true }
-- { name: hledger-ui,                  verpat: ".*\.99\b.*",                               incorrect: true }
-- { name: hledger-web,                 verpat: ".*\.99\b.*",                               incorrect: true }
+- { name: hledger,                     verpat: ".*\\.99\\b.*",                             incorrect: true }
+- { name: hledger-lib,                 verpat: ".*\\.99\\b.*",                             incorrect: true }
+- { name: hledger-ui,                  verpat: ".*\\.99\\b.*",                             incorrect: true }
+- { name: hledger-web,                 verpat: ".*\\.99\\b.*",                             incorrect: true }
 - { name: hmmer,                       verpat: ".*b.*",                                    devel: true }
 - { name: hnb,                         ver: [ "1.9.18", "1.9.19" ],                        ignore: true } # unofficial
 - { name: horizon,                     verpat: "20[0-9]{2}\\..*",                          sink: true }


### PR DESCRIPTION
And any other mistaken release of .99 versions in future.