### PR TITLE
Drop odd/even devel rule for deja-dup

### DIFF
--- a/900.version-fixes/d.yaml
+++ b/900.version-fixes/d.yaml
@@ -41,7 +41,6 @@
 - { name: deepin-sound-theme,          ver: "17.07.31",              ruleset: pardus,      ignore: true }
 - { name: deepin-utils,                                                                    noscheme: true }
 - { name: dehydrated,                  verlonger: 3,                                       incorrect: true } # freebsd
-- { name: deja-dup,                    verpat: "[0-9]*[13579]\\..*",                       devel: true }
 - { name: delta-file-minimizer,        ver: "20060803",                                    incorrect: true } # 2006.08.03
 - { name: demoroniser,                                                                     noscheme: true }
 - { name: denemo,                      verpat: "20[0-9]{6}",                               snapshot: true }


### PR DESCRIPTION
It now follows a GNOME-style XX.alpha or XX.beta pattern for devel releases.

Source: am the maintainer. But also the [NEWS](https://gitlab.gnome.org/World/deja-dup/-/blob/main/NEWS.md) file.