### PR TITLE
remove LAStools noscheme rule due to v2.0.0 announcement

### DIFF
--- a/900.version-fixes/l.yaml
+++ b/900.version-fixes/l.yaml
@@ -10,7 +10,8 @@
 - { name: langkit,                                                                         noscheme: true }
 - { name: lasem,                       verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
 - { name: lash,                        verpat: "0\\.6\\.0\\.[0-9]{3}.*",                   incorrect: true } # 0.6.0rc2
-- { name: lastools,                                                                        noscheme: true } # 0.6.0rc2
+- { name: lastools,                    verpat: "[0-9]{6}",                                 sink: true } # upstream used yymmdd prior to v2.0.0
+- { name: lastools,                    verpat: "[0-9]{2}[.-][0-9]{2}[.-][0-9]{2}",         sink: true } # some distros packaged as yy-mm-dd or yy.mm.dd
 - { name: latexmk,                     verpat: "[0-9]{3}.*",                               incorrect: true } # 4.69, not 469
 - { name: latte-dock,                  verpat: "[0-9]+\\.[0-9]+\\.[89][0-9]+",             devel: true }
 - { name: lazarus,                     ver: "2.0.1",                 ruleset: sisyphus,    incorrect: true }


### PR DESCRIPTION
Per https://github.com/LAStools/LAStools/releases/tag/v2.0.0:

> Due some requests we start to use the git release feature starting now.
LAStools use a versioning in YYMMDD scheme. This is common for most LAStools users for long time - so we keep this version numbers.
Additionally we will follow the git versioning guidelines for the open source releases. They may also flow into sourcecode next.
Cause we have quite something like a history we start straight away with version 2.0.0.