### PR TITLE
Merge for rofi-wayland

### DIFF
--- a/800.renames-and-merges/r.yaml
+++ b/800.renames-and-merges/r.yaml
@@ -82,6 +82,7 @@
 - { setname: rna-star,                 name: [star-aligner,star-seq-alignment,starlong] }
 - { setname: rna-star,                 name: star-cshl, addflavor: cshl } # aur
 - { setname: rocketchat-client,        name: [rocket.chat-desktop, rocket-chat, rocketchat, rocketchat-desktop] }
+- { setname: rofi-wayland,             name: [rofi-lbonn-wayland] } # aur
 - { setname: roguebox-adventures,      name: rogueboxadventures }
 - { setname: ronn,                     name: "ruby:ronn" }
 - { setname: roomeqwizard,             name: room-eq-wizard }


### PR DESCRIPTION
It would be good to have https://aur.archlinux.org/packages/rofi-lbonn-wayland-git/ as a result for AUR in the [rofi-wayland version page](https://repology.org/project/rofi-wayland/versions)

The current project link (https://aur.archlinux.org/packages/rofi-wayland-git) is deprecated and does not work on modern systems but I don't know if marking it as deprecated is needed or will it just be superseded by rofi-lbonn-wayland-git after this change?