### PR TITLE
Remove obsolete noscheme for nextpnr

### DIFF
--- a/900.version-fixes/n.yaml
+++ b/900.version-fixes/n.yaml
@@ -71,7 +71,6 @@
 - { name: newlib,                      verpat: ".*20[0-9]{6}",                             snapshot: true }
 - { name: newlisp,                     vergt: "10.7.1",                                    devel: true, maintenance: true } # http://www.newlisp.org/
 - { name: nextcloud-client,            verpat: ".+20[0-9]{6}",                             snapshot: true } # winget
-- { name: nextpnr,                                                                         noscheme: true }
 - { name: nexuiz,                      verpat: "[0-9]{2}",                                 incorrect: true } # T2; 2.5.2, not 25
 - { name: nginx,                       verpat: "[0-9]+(\\.[0-9]+){2}",                     devel: false } # mainline version is not beta/devel, explained here: https://www.nginx.com/blog/nginx-1-6-1-7-released/
 - { name: nginx,                       verpat: ".*quic",                                   incorrect: true }


### PR DESCRIPTION
nextpnr started creating releases a couple monts ago and released three versions so far: https://github.com/YosysHQ/nextpnr/releases.