### PR TITLE
Merge gnome:manager into extension-manager

### DIFF
--- a/800.renames-and-merges/e.yaml
+++ b/800.renames-and-merges/e.yaml
@@ -162,6 +162,7 @@
 - { setname: exosip,                   name: [libexosip,libexosip2,exosip2] }
 - { setname: expat,                    namepat: "(?:compat-)?(?:lib)?expat[0-9.-]*" }
 - { setname: expect,                   name: tcl-expect }
+- { setname: extension-manager,        name: gnome:manager }
 - { setname: extremetuxracer,          name: [etr, etracer,extreme-tuxracer,extreme-tux-racer] }
 - { setname: exuberant-ctags,          name: [ectags,exctags,exuberantctags] }
 - { setname: eyed3,                    name: "python:eyed3" }


### PR DESCRIPTION
Hi,

[extension-manager](https://repology.org/project/extension-manager/versions) is packaged as [gnome-shell-extension-manager](https://repology.org/project/gnome:manager/versions) on Debian and its derivatives.

This merges `gnome:manager` into the more widely used name `extension-manager`.