### PR TITLE
Match openSUSE's btrfsprogs as btrfs-progs

### DIFF
--- a/800.renames-and-merges/b.yaml
+++ b/800.renames-and-merges/b.yaml
@@ -183,6 +183,7 @@
 - { setname: btanks,                   name: battle-tanks }
 - { setname: btanks,                   name: btanks-data, addflavor: data }
 - { setname: btrfs-backup,             name: "python:btrfs-backup" }
+- { setname: btrfs-progs,              name: btrfsprogs }
 - { setname: bubblefishymon,           name: bubblefishymod }
 - { setname: bubbros,                  name: bub-n-bros, ruleset: gentoo } # XXX: recheck
 - { setname: bucardo,                  name: "perl:bucardo" }


### PR DESCRIPTION
https://repology.org/project/btrfs-progs/information
vs
https://repology.org/project/btrfsprogs/information