### PR TITLE
Add devel rules for gssdp and gupnp

### DIFF
--- a/900.version-fixes/g.yaml
+++ b/900.version-fixes/g.yaml
@@ -284,6 +284,7 @@
 - { name: gsmc,                        ver: "1.2.1",                 ruleset: debuntu,     incorrect: true }
 - { name: gsmc,                                                      ruleset: debuntu,     untrusted: true } # accused of fake 1.2.1
 - { name: gsmlib,                                                                          noscheme: true }
+- { name: gssdp,                       verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
 - { name: gst-python,                  verpat: "1\\.[0-9]*[13579]\\..*",                   devel: true }
 - { namepat: "gstreamer:.*",           verpat: "1\\.[0-9]*[13579]\\..*",                   devel: true }
 - { name: "gstreamer:bad",             ver: "1.14.12",               ruleset: parabola,    incorrect: true }
@@ -321,6 +322,7 @@
 - { name: gumbo-parser,                                              ruleset: yacp,        untrusted: true }
 - { name: gummi,                       ver: "0.7.4.3",               ruleset: opensuse,    incorrect: true }
 - { name: gummi,                                                     ruleset: opensuse,    untrusted: true }
+- { name: gupnp,                       verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
 - { name: gupnp-igd,                   ver: "0.20.16",               ruleset: pisi,        incorrect: true }
 - { name: gupnp-igd,                                                 ruleset: pisi,        untrusted: true } # accused of fake 0.20.16
 - { name: gvfs,                        verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }


### PR DESCRIPTION
These are development versions. See https://discourse.gnome.org/t/new-development-releases-for-gssdp-and-gupnp/9584