### PR TITLE
Split the system monitors (GNOME Shell extensions)

### DIFF
--- a/850.split-ambiguities/g.yaml
+++ b/850.split-ambiguities/g.yaml
@@ -110,6 +110,7 @@
 - { name: gnat-util, ruleset: [freebsd,pkgsrc,ravenports], setname: gnat-util-gcc }
 - { name: gnat-util, addflag: unclassified }
 
+- { name: gnome:system-monitor, wwwpart: [extensions.gnome.org/extension/120/, github.com/paradoxxxzero], setname: gnome:paradoxxxzero-system-monitor }
 - { name: gnome:system-monitor, wwwpart: extensions.gnome.org/extension/1064/, setname: gnome:elvetemedve-system-monitor }
 
 - { name: gnupg, wwwpart: gpg4win, setname: gpg4win } # XXX: problem?

--- a/850.split-ambiguities/g.yaml
+++ b/850.split-ambiguities/g.yaml
@@ -110,6 +110,8 @@
 - { name: gnat-util, ruleset: [freebsd,pkgsrc,ravenports], setname: gnat-util-gcc }
 - { name: gnat-util, addflag: unclassified }
 
+- { name: gnome:system-monitor, wwwpart: extensions.gnome.org/extension/1064/, setname: gnome:elvetemedve-system-monitor }
+
 - { name: gnupg, wwwpart: gpg4win, setname: gpg4win } # XXX: problem?
 
 - { name: gnustep-pixen, wwwpart: pixenapp.com, successor: true } # became proprietary, bug there is GH fork containing source


### PR DESCRIPTION
GNOME Shell extension store URL:

- https://extensions.gnome.org/extension/120/system-monitor/
- https://extensions.gnome.org/extension/1064/system-monitor/

They served the same purpose, so took the same name. Probably developed independently. As we can tell from the extension identifier number, the 120 one is earlier (and also more popular), so I think it should take the name. I also assumed that I should keep using `gnome:` prefix for shell extensions.