### PR TITLE
Merge further packages into maui-nota

### DIFF
--- a/850.split-ambiguities/n.yaml
+++ b/850.split-ambiguities/n.yaml
@@ -100,7 +100,8 @@
 - { name: nonpareil, wwwpart: enve-omics, setname: nonpareil-metagenomic-coverage }
 - { name: nonpareil, addflag: unclassified }
 
-- { name: nota, wwwpart: kde, setname: maui-nota }
+- { name: nota, wwwpart: [kde,maui], setname: maui-nota }
+- { name: nota, ruleset: openmandriva, setname: maui-nota }
 - { name: nota, wwwpart: cdown, setname: nota-note-taking }
 - { name: nota, wwwpart: kary.us, setname: nota-calculator }
 - { name: nota, addflag: unclassified }


### PR DESCRIPTION
+ If a distribution refers to MauiKit's GitHub Mirrors (e.g. KDE Neon
Unstable does this), Nota should be now matched correctly.
+ OpenMandriva 4.2 does not specify an URL, therefore this entry
needs to be manually moved to the maui-nota project.

I ran `make check`. This should move those two packages in nota-unclassified to their correct project. Hope I did everything alright and feel free to remove that commit message if it's too noisy.

Thank you for maintaining such a valuable project :pray: