### PR TITLE
Merge calindori

### DIFF
--- a/800.renames-and-merges/c.yaml
+++ b/800.renames-and-merges/c.yaml
@@ -27,6 +27,7 @@
 - { setname: calculix-cgx,             name: cgx }
 - { setname: calculix-cgx,             name: [calculix-cgx-doc], addflavor: true }
 - { setname: calibre,                  name: [calibre-debug,calibre-normal], addflavor: true }
+- { setname: calindori,                name: kde5-calindori }
 - { setname: calligra-l10n,            namepat: "calligra-l10n-(.*)", addflavor: $1 }
 - { setname: calligraplan,             name: calligra-plan }
 - { setname: camlp5,                   name: "ocaml:camlp5" }


### PR DESCRIPTION
The Alt Linux packages `kde5-calindori` are the same project as `calindori`.
Hope I didn't oversee anything again^^