### PR TITLE
Merge system-monitor-applet into system-monitor (the “paradoxxxzero” one)

### DIFF
--- a/800.renames-and-merges/g.yaml
+++ b/800.renames-and-merges/g.yaml
@@ -248,6 +248,7 @@
 - { setname: gnome-themes-extra,       name: gnome-themes-standard }
 - { setname: gnome-tweaks,             name: gnome-tweak-tool } # former name; XXX: problem
 - { setname: gnome-vfs,                name: gnome-vfs-reference, addflavor: true }
+- { setname: gnome:system-monitor-paradoxxxzero, name: gnome-monitor-applet }
 - { setname: gnonlin,                  name: gnonlin1.0 }
 - { setname: gnu-efi,                  namepat: "gnu-efi[0-9.-]*[a-z]?" }
 - { setname: gnu-efi,                  name: gnu-efi-libs, addflavor: true }


### PR DESCRIPTION
Follow up of #619. The `-applet` package points to the GNOME-Extension URL with 120, so it is the paradox-zero one.