### PR TITLE
Rename chrome-gnome-shell to gnome-browser-connector

### DIFF
--- a/800.renames-and-merges/g.yaml
+++ b/800.renames-and-merges/g.yaml
@@ -215,6 +215,7 @@
 - { setname: gnet,                     name: libgnet }
 - { setname: gnome-2048,               name: [gnome-games-2048, gnome2048] }
 - { setname: gnome-bluetooth,          namepat: "(?:compat-)?gnome-bluetooth[0-9.-]*" }
+- { setname: gnome-browser-connector,  name: chrome-gnome-shell }
 - { setname: gnome-calculator,         name: gcalctool }
 - { setname: gnome-calculator,         name: gcalctool-oldgui, addflavor: true }
 - { setname: gnome-calculator,         name: gnome-calculator-41 }


### PR DESCRIPTION
See-Also: https://gitlab.gnome.org/GNOME/gnome-browser-extension/-/commit/4784cc2531f8557b627de502e5ee7bff3552101d