### PR TITLE
Merge manpages-l10n

### DIFF
--- a/800.renames-and-merges/m.yaml
+++ b/800.renames-and-merges/m.yaml
@@ -33,6 +33,7 @@
 - { setname: mandoc,                   name: mdocml } # mdocml is an old name (schwarze@openbsd.org)
 - { setname: mandown,                  name: "rust:$0" }
 - { setname: manpages,                 name: [man-pages,linux-man-pages,linux-manpages] }
+- { setname: manpages-l10n,            name: [man-pages-l10n, manpages-pt-br] }
 - { setname: manpages-zh,              name: [man-pages-zh, man-pages-zh-cn] } # upstream claims that this is the official name
 - { setname: mapnik,                   name: libmapnik }
 - { setname: mapproxy,                 name: "python:mapproxy" }


### PR DESCRIPTION
[manpages-l10n](https://salsa.debian.org/manpages-l10n-team/manpages-l10n) is the upstream name, but some distros package it as [man-pages-l10n](https://repology.org/project/man-pages-l10n/) to meet the [man-pages](https://repology.org/project/manpages/versions) package name.

While most distros name it [manpages-l10n](https://repology.org/project/manpages-l10n/) or man-pages-l10n to then be split into specific languages package, Void Linux names the root package as [manpages-pt-br](https://repology.org/project/manpages-pt-br/versions) (see its [package template](https://github.com/void-linux/void-packages/blob/master/srcpkgs/manpages-pt-br/template)) — I bet its maintainer is Brazilian.

So here is my proposal to make manpages-l10n, man-pages-l10n and manpages-pt-br a single project in repology.