### PR TITLE
Drop devel rule for gnutls 3.7

### DIFF
--- a/900.version-fixes/g.yaml
+++ b/900.version-fixes/g.yaml
@@ -208,7 +208,6 @@
 - { name: gnuradio,                    verpat: ".*t.*",                                    ignore: true } # tech preview
 - { name: gnustep-edenmath,            ver: "1.1.1a",                                      incorrect: true } # debian fake; their archive of "1.1.1a" only mentions 1.1.1
 - { name: gnustep-pikopixel,           verpat: ".*b.*",                                    devel: true }
-- { name: gnutls,                      verpat: "3\\.7\\..*",                               devel: true, maintenance: true } # stable-next branch; it's claimed to be stable but undertested, but in fact it is widely used already, so `devel' is not entirely correct here, but use it to allow 3.6 and 3.5 coexist for now
 - { name: go,                                                        ruleset: aur,         untrusted: true } # blunt lie https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=go1.13
 - { name: "go:bindata",                verpat: "20[0-9]{6}.*",                             ignore: true }
 - { name: "go:bindata",                ver: "3.1.0",                 ruleset: freebsd,     incorrect: true }


### PR DESCRIPTION
I believe that's really wrong.
3.6.x is long unmaintained and it contains security bugs,
 https://gnutls.org/security-new.html
so repology shouldn't show that as the green one.
(Distros might've patched the issues, of course.)