### PR TITLE
Add verignore for element-desktop

### DIFF
--- a/900.version-fixes/e.yaml
+++ b/900.version-fixes/e.yaml
@@ -47,6 +47,7 @@
 - { name: electricfence,               ver: "2_4_13",                                      incorrect: true }
 - { name: electricfence,                                             ruleset: t2,          untrusted: true } # accused of fake 2_4_13
 - { name: electricsheep,                                                                   noscheme: true } # https://github.com/scottdraves/electricsheep/releases
+- { name: element-desktop,             verpat: "[0-9]+.[0-9]+.[0-9]+_.*",                  incorrect: true }
 - { name: elementary,                  verpat: "20[0-9]{6}",                               snapshot: true }
 - { name: elementary,                  ver: "2009-07-29",                                  sink: true }
 - { name: elementary-settings-daemon,  ver: "3.34.1",                                      incorrect: true }


### PR DESCRIPTION
See https://repology.org/project/element-desktop/versions, which has 1.11.4_1 as latest, which is not an upstream release.
