### PR TITLE
Merge krecorder

### DIFF
--- a/800.renames-and-merges/kde.yaml
+++ b/800.renames-and-merges/kde.yaml
@@ -253,6 +253,7 @@
     kpty|
     kquickcharts|
     krdc|
+    krecorder|
     kremotecontrol|
     krename|
     kreport|


### PR DESCRIPTION
ALT Linux uses the `kde5-` prefix, it should be merged into `krecorder`.