### PR TITLE
Disambiguation for `mdl`

### DIFF
--- a/800.renames-and-merges/m.yaml
+++ b/800.renames-and-merges/m.yaml
@@ -132,6 +132,8 @@
 - { setname: mdformat,                 name: "python:$0" }
 - { setname: mdk,                      name: gnu-mdk }
 - { setname: mdk,                      name: mdk-doc, addflavor: true }
+# All the MDLs get disambiguated in the 850 ruleset
+- { setname: mdl,                      name: "ruby:mdl" }
 - { setname: mdp,                      name: gpg-mdp } # different from mdp-src, split in 850
 - { setname: mdp,                      name: mdp-src } # different from gpg-mdp, split in 850
 - { setname: me-cleaner,               name: "python:me-cleaner" }

--- a/850.split-ambiguities/m.yaml
+++ b/850.split-ambiguities/m.yaml
@@ -77,6 +77,11 @@
 - { name: mdk, wwwpart: wlan, setname: mdk-wireless-injection }
 # otherwise, GNU MIX Development Kit
 
+- { name: mdl, wwwpart: [markdownlint/markdownlint,rubygems], setname: "mdl-markdownlint" }
+- { name: mdl, wwwpart: [DavidAnson], setname: "mdl-markdownlint-node" }
+- { name: mdl, wwwpart: dopsi, setname: "mdl-markdownless" }
+- { name: mdl, addflag: unclassified }
+
 - { name: mdp, wwwpart: [toolkit,mdpdocs.readthedocs], setname: "python:mdp" }
 - { name: mdp, wwwpart: visit1985, setname: mdp-markdown-presentation-tool }
 - { name: mdp, wwwpart: navy.mil, setname: mdp-multicast-file-transfer }


### PR DESCRIPTION
Disabmiguate `markdownlint` vs `markdownless`

Signed-off-by: Phil Dibowitz <phil@ipom.com>
