### PR TITLE
Merge drgn

### DIFF
--- a/800.renames-and-merges/d.yaml
+++ b/800.renames-and-merges/d.yaml
@@ -149,6 +149,7 @@
 - { setname: drbl,                     name: drbl-experimental, ignore: true }
 - { setname: dreampie,                 name: "python:dreampie" }
 - { setname: drgeo,                    name: drgeo1 }
+- { setname: drgn,                     name: "python:drgn" }
 - { setname: drkonqi,                  name: drkonqi5 }
 - { setname: drpython,                 name: drpython-py27 }
 - { setname: drumkv1,                  name: drumkv1-lv2 }


### PR DESCRIPTION
It's showing as both `drgn` and `python:drgn`; as it is more of a tool than a Python module, merging into `drgn` seems more appropriate

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>