### PR TITLE
Add elpa-php-mode to emacs:php-mode

### DIFF
--- a/800.renames-and-merges/emacs.yaml
+++ b/800.renames-and-merges/emacs.yaml
@@ -78,7 +78,7 @@
 - { setname: "emacs:org-mode",         name: org-mode-doc, addflavor: doc }
 - { setname: "emacs:p4",               name: p4.el }
 - { setname: "emacs:paredit",          name: [emacs-paredit,paredit-el,paredit-mode.el] }
-- { setname: "emacs:php-mode",         name: [emacs-php-mode,php-mode.el,php-elisp] }
+- { setname: "emacs:php-mode",         name: [emacs-php-mode,php-mode.el,php-elisp,elpa-php-mode] }
 - { setname: "emacs:pkg-info",         name: [emacs-pkg-info,pkg-info-el,pkg-info.el] }
 - { setname: "emacs:planner",          name: [emacs-planner,planner-el] }
 - { setname: "emacs:popup",            name: [emacs-popup,emacs-popup-el,popup-el] }


### PR DESCRIPTION
Emacs php-mode is now provided in Debian as [elpa-php-mode](https://packages.debian.org/stable/elpa-php-mode). refs https://github.com/emacs-php/php-mode/issues/430

Emacs Lisp packages now tend to be `elpa-` prefixed on Debian.