### PR TITLE
Translate old AdaCore version scheme to new one for gprbuild and gnatcoll-*

### DIFF
--- a/900.version-fixes/g.yaml
+++ b/900.version-fixes/g.yaml
@@ -141,8 +141,9 @@
 - { name: gnash,                       ver: "0.8.11",                ruleset: debuntu,     ignore: true } # not released yet
 - { name: gnat-programming-studio,                                                         noscheme: true }
 - { name: gnat-util-gcc,                                                                   noscheme: true }
-- { name: gnatcoll-bindings,                                                               noscheme: true }
-- { name: gnatcoll-db,                                                                     noscheme: true }
+- { name: gnatcoll-bindings,           verpat: "20[0-9]{2}",                               sink: true }
+- { name: gnatcoll-core,               verpat: "20[0-9]{2}",                               sink: true }
+- { name: gnatcoll-db,                 verpat: "20[0-9]{2}",                               sink: true }
 - { name: gnome-2048,                  verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
 - { name: gnome-activity-journal,      verpat: ".*is.really.*",                            incorrect: true }
 - { name: gnome-applets,               verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
@@ -251,7 +252,7 @@
 - { name: gping,                       ver: "1.1",                                         sink: true } # python version, rewritten in rust with other versioning scheme
 - { name: gpm,                         verpat: "[0-9]+\\.99\\..*",                         devel: true } # assumed
 - { name: gprbuild,                    verpat: "[0-9]{5,}.*",                              incorrect: true }
-- { name: gprbuild,                    verlonger: 1,                                       incorrect: true }
+- { name: gprbuild,                    verpat: "20[0-9]{2}",                               sink: true }
 - { name: gpredict,                    ver: "2.3",                                         devel: true } # https://github.com/csete/gpredict/releases/tag/v2.3
 - { name: gprolog,                                                   ruleset: debuntu,     untrusted: true } # accused of fake 1.4.5
 - { name: gpsbabel,                    ver: "1.6.0.1",                                     setver: "1.6.0", disposable: true } # tags point to same commit


### PR DESCRIPTION
Relevant bits from the commit messages:

---

AdaCore seems to have switched version schemes in a way: They used
publish the GNATCOLL libraries with a year as the version number.
Starting with 2021 they seem to use the last two digits of the
year followed by two version parts which have all been zero so far.
This can be seen from the GitHub release pages:

* https://github.com/AdaCore/gnatcoll-core/releases/
* https://github.com/AdaCore/gnatcoll-db/releases/
* https://github.com/AdaCore/gnatcoll-bindings/releases/

The GNATCOLL docs seem to use an YY.0w scheme I can't quite
figure out, but this is unused by any package repository, e.g.

* https://docs.adacore.com/gnatcoll-docs/
* https://docs.adacore.com/live/wave/gnatcoll-core/html/gnatcoll-core_ug/index.html
* https://docs.adacore.com/live/wave/gnatcoll-iconv/html/gnatcoll-iconv_ug/index.html
* https://docs.adacore.com/live/wave/gnatcoll-syslog/html/gnatcoll-syslog_ug/index.html
* https://docs.adacore.com/live/wave/gnatcoll-readline/html/gnatcoll-readline_ug/index.html

---

For gprbuild it's the same story as with gnatcoll-*: AdaCore switched
to using YY.0.0 version strings over a 20YY year number in 2021:
https://github.com/AdaCore/gprbuild/releases

The alternative version number of YY.0w is only used in the docs,
but in no package repository at the moment:
https://docs.adacore.com/gprbuild-docs/html/gprbuild_ug.html