### PR TITLE
Merge subprojects into gnatcoll-bindings, gnatcoll-db

### DIFF
--- a/800.renames-and-merges/g.yaml
+++ b/800.renames-and-merges/g.yaml
@@ -215,6 +215,21 @@
 - { setname: gn,                       name: generate-ninja }
 - { setname: gnash,                    name: gnash-git, ignore: true }
 - { setname: gnat-programming-studio,  name: [gnat-gps, gnatstudio] }
+- { setname: gnatcoll-bindings,        name: gnatcoll-gmp,      addflavor: gmp }
+- { setname: gnatcoll-bindings,        name: gnatcoll-iconv,    addflavor: iconv }
+- { setname: gnatcoll-bindings,        name: gnatcoll-lzma,     addflavor: lzma }
+- { setname: gnatcoll-bindings,        name: gnatcoll-omp,      addflavor: omp }
+- { setname: gnatcoll-bindings,        name: gnatcoll-python,   addflavor: python }
+- { setname: gnatcoll-bindings,        name: gnatcoll-python3,  addflavor: python3 }
+- { setname: gnatcoll-bindings,        name: gnatcoll-readline, addflavor: readline }
+- { setname: gnatcoll-bindings,        name: gnatcoll-syslog,   addflavor: syslog }
+- { setname: gnatcoll-bindings,        name: gnatcoll-zlib,     addflavor: zlib }
+- { setname: gnatcoll-db,              name: gnatinspect,       addflavor: gnatinspect }
+- { setname: gnatcoll-db,              name: gnatcoll-db2ada,   addflavor: db2ada }
+- { setname: gnatcoll-db,              name: gnatcoll-postgres, addflavor: postgres }
+- { setname: gnatcoll-db,              name: gnatcoll-sql,      addflavor: sql }
+- { setname: gnatcoll-db,              name: gnatcoll-sqlite,   addflavor: sqlite }
+- { setname: gnatcoll-db,              name: gnatcoll-xref,     addflavor: xref }
 - { setname: gnats,                    namepat: "gnats[0-9]+" }
 - { setname: gnet,                     namepat: "gnet[0-9]+" }
 - { setname: gnet,                     name: libgnet }

--- a/800.renames-and-merges/g.yaml
+++ b/800.renames-and-merges/g.yaml
@@ -215,6 +215,8 @@
 - { setname: gn,                       name: generate-ninja }
 - { setname: gnash,                    name: gnash-git, ignore: true }
 - { setname: gnat-programming-studio,  name: [gnat-gps, gnatstudio] }
+- { setname: gnatcoll-bindings,        name: libgnatcoll-bindings }
+- { setname: gnatcoll-bindings,        name: libgnatcoll-python, addflavor: python }
 - { setname: gnatcoll-bindings,        name: gnatcoll-gmp,      addflavor: gmp }
 - { setname: gnatcoll-bindings,        name: gnatcoll-iconv,    addflavor: iconv }
 - { setname: gnatcoll-bindings,        name: gnatcoll-lzma,     addflavor: lzma }
@@ -224,6 +226,7 @@
 - { setname: gnatcoll-bindings,        name: gnatcoll-readline, addflavor: readline }
 - { setname: gnatcoll-bindings,        name: gnatcoll-syslog,   addflavor: syslog }
 - { setname: gnatcoll-bindings,        name: gnatcoll-zlib,     addflavor: zlib }
+- { setname: gnatcoll-db,              name: libgnatcoll-db }
 - { setname: gnatcoll-db,              name: gnatinspect,       addflavor: gnatinspect }
 - { setname: gnatcoll-db,              name: gnatcoll-db2ada,   addflavor: db2ada }
 - { setname: gnatcoll-db,              name: gnatcoll-postgres, addflavor: postgres }


### PR DESCRIPTION
The AdaCore repositories

* https://github.com/AdaCore/gnatcoll-bindings
* https://github.com/AdaCore/gnatcoll-db

contain a number of sublibraries (and executables) that are developed and released together. Some repositories split these up into their respective subprojects (nixpkgs, AUR) others package them all together (Fedora). For the former the projects gnatcoll-db and gnatcoll-bindings would not exist whereas it would be the only packages existing in the latter repositories.

To alleviate this, we just merge them all into those two names. As the libraries are interdependent it seems unlikely that mismatched versions can legitimately be in the same repository.

**Note** that this means for repositories like AUR and nixpkgs, multiple projects existing in the repository would be merged into one – I can't tell if that's a problem for repology.

(gnatcoll-db2ada and gnatinspect are currently named incorrectly in nixpkgs, but this will be fixed with
https://github.com/NixOS/nixpkgs/pull/201026/commits/ad3c52bf07a1c1295840fe3311cd53c390a6ab39)