### PR TITLE
Mark 20YY.0.0 versions as incorrect for gprbuild

### DIFF
--- a/900.version-fixes/g.yaml
+++ b/900.version-fixes/g.yaml
@@ -252,6 +252,7 @@
 - { name: gping,                       ver: "1.1",                                         sink: true } # python version, rewritten in rust with other versioning scheme
 - { name: gpm,                         verpat: "[0-9]+\\.99\\..*",                         devel: true } # assumed
 - { name: gprbuild,                    verpat: "[0-9]{5,}.*",                              incorrect: true }
+- { name: gprbuild,                    verpat: "20[0-9]{2}\\.[0-9]+\\.[0-9]+",             incorrect: true }
 - { name: gprbuild,                    verpat: "20[0-9]{2}",                               sink: true }
 - { name: gpredict,                    ver: "2.3",                                         devel: true } # https://github.com/csete/gpredict/releases/tag/v2.3
 - { name: gprolog,                                                   ruleset: debuntu,     untrusted: true } # accused of fake 1.4.5


### PR DESCRIPTION
Correct would be YY.0.0, using the full "year" seems to be some repositories trying to carry an old scheme forwards incorrectly. This is only a problem for gprbuild at the moment, the gnatcoll-* packages are all imported correctly.