### PR TITLE
Disambiguate markdown ada module

### DIFF
--- a/850.split-ambiguities/m.yaml
+++ b/850.split-ambiguities/m.yaml
@@ -37,6 +37,8 @@
 - { name: mantra, wwwpart: 0mp, setname: mantra-0mp }
 - { name: mantra, addflag: unclassified }
 
+- { name: markdown, wwwpart: AdaCore, setname: "ada:markdown"}
+
 - { name: mars, category: games, setname: m.a.r.s. }
 - { name: mars, wwwpart: [marsshooter,mars-game], setname: m.a.r.s. }
 - { name: mars, wwwpart: www.mpibpc.mpg.de, setname: mars-proteins-assignment }


### PR DESCRIPTION
A package from AUR called markdown, which is an ADA module, is conflated with the markdown application from daringfireball.