### PR TITLE
Update shotcut development version to 22.12.04

### DIFF
--- a/900.version-fixes/s.yaml
+++ b/900.version-fixes/s.yaml
@@ -135,7 +135,7 @@
 - { name: shockolate,                  verlonger: 3,                 ruleset: freebsd,     incorrect: true }
 - { name: shotcut,                     verpat: "[0-9]{6,}.*",                              incorrect: true } # aur; it's not 180102, but 18.01
 - { name: shotcut,                     verpat: ".+20[0-9]{6}",                             snapshot: true } # funtoo
-- { name: shotcut,                     ver: "19.08.05",                                    devel: true, maintenance: true } # https://github.com/mltframework/shotcut/releases
+- { name: shotcut,                     ver: "22.12.04",                                    devel: true, maintenance: true } # https://github.com/mltframework/shotcut/releases
 - { name: shotcut,                     ver: "21.04.14",                                    incorrect: true }
 - { name: shotcut,                                                   ruleset: winget,      untrusted: true } # accused of fake 21.04.14
 - { name: shotgun-debugger,            wwwpart: msarnoff,                                  successor: true }


### PR DESCRIPTION
Version 22.12.04 is marked as [beta][0].

[0]: https://github.com/mltframework/shotcut/releases/tag/v22.12.04