### PR TITLE
Ignore atk 2.46.0 from gentoo

### DIFF
--- a/900.version-fixes/a.yaml
+++ b/900.version-fixes/a.yaml
@@ -274,6 +274,7 @@
 - { name: at-spi2-core,                ver: "2.34.1",                ruleset: pisi,        incorrect: true, disposable: true }
 - { name: atheme,                      verpat: ".*r[0-9].*",                               any_is_patch: true }
 - { name: atk,                         verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
+- { name: atk,                         ver: "2.46.0",                ruleset: gentoo,      incorrect: true }
 - { name: atkmm,                       verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
 - { name: atlas-linear-algebra,        verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
 - { name: atom,                        ver: "1.61.0",                ruleset: solus,       incorrect: true }


### PR DESCRIPTION
As [explained in Gentoo's repository](https://gitweb.gentoo.org/repo/gentoo.git/commit/dev-libs/atk?id=680a9a048f812387fd64f82d79cb533b1c9fedc1) ATK 2.46.0 published in Gentoo repositories is a dummy package for
at-spi2-core, and is incorrect. The latest version according to the [source repository](https://gitlab.gnome.org/GNOME/atk/-/tags) is 2.38.0
