### PR TITLE
Add disambiguation for crane

### DIFF
--- a/850.split-ambiguities/c.yaml
+++ b/850.split-ambiguities/c.yaml
@@ -165,6 +165,11 @@
 - { name: cortex, wwwpart: cortexmetrics, setname: cortex-prometeus-storage }
 - { name: cortex, addflag: unclassified }
 
+- { name: crane, wwwpart: michaelsauter, setname: michaelsauter-crane }
+- { name: crane, wwwpart: go-containerregistry, setname: go:containerregistry }
+- { name: crane, wwwpart: ewilde, setname: ewilde-crane }
+- { name: crane, addflag: unclassified }
+
 - { name: crimson, wwwpart: [java,xml,apache], setname: crimson-jaxp }
 - { name: crimson, wwwpart: [aldusleaf,skosch], setname: "fonts:crimson" }
 - { name: crimson, addflag: unclassified }


### PR DESCRIPTION
Three distinct projects with the same name exist:

- https://github.com/michaelsauter/crane docker-compose like project
- https://github.com/ewilde/crane dotnet build tool
- https://github.com/google/go-containerregistry/tree/main/cmd/crane
  tool to interact with images and registries