### PR TITLE
Drill is called ldns when provided by nlnetlabs.nl

### DIFF
--- a/800.renames-and-merges/d.yaml
+++ b/800.renames-and-merges/d.yaml
@@ -150,6 +150,7 @@
 - { setname: dreampie,                 name: "python:dreampie" }
 - { setname: drgeo,                    name: drgeo1 }
 - { setname: drgn,                     name: "python:drgn" }
+- { setname: drill,                    name: "rust:$0" }
 - { setname: drkonqi,                  name: drkonqi5 }
 - { setname: drpython,                 name: drpython-py27 }
 - { setname: drumkv1,                  name: drumkv1-lv2 }

--- a/850.split-ambiguities/d.yaml
+++ b/850.split-ambiguities/d.yaml
@@ -192,7 +192,7 @@
 - { name: drgeo, wwwpart: drgeo.eu, setname: gnu-drgeo }
 
 - { name: drill, wwwpart: apache.org,  setname: apache-drill }
-- { name: drill, setname: ldns }
+- { name: drill, wwwpart: nlnetlabs.nl, setname: ldns }
 
 - { name: drive, wwwpart: odeke-em, setname: drive-google-drive-cli }
 - { name: drive, wwwpart: google.com, setname: drive-google }

--- a/850.split-ambiguities/d.yaml
+++ b/850.split-ambiguities/d.yaml
@@ -192,7 +192,9 @@
 - { name: drgeo, wwwpart: drgeo.eu, setname: gnu-drgeo }
 
 - { name: drill, wwwpart: apache.org,  setname: apache-drill }
-- { name: drill, wwwpart: nlnetlabs.nl, setname: ldns }
+- { name: drill, wwwpart: nlnetlabs, setname: ldns }
+- { name: drill, wwwpart: fcsonline, setname: drill-http-load-testing }
+- { name: drill, addflag: unclassified }
 
 - { name: drive, wwwpart: odeke-em, setname: drive-google-drive-cli }
 - { name: drive, wwwpart: google.com, setname: drive-google }


### PR DESCRIPTION
See https://gitlab.alpinelinux.org/alpine/aports/-/issues/14553

The drill package in arch linux is a subpackage, that contains the drill binary from ldns. There is also a drill package at https://github.com/fcsonline/drill, that is completely different

The ldns package in repology contains mixed versions due to this:: https://repology.org/project/ldns/versions

Drill from ldns is at version 1.8.3
Drill is version 0.8.1