### PR TITLE
Separate blackarch's snitch from others

### DIFF
--- a/850.split-ambiguities/s.yaml
+++ b/850.split-ambiguities/s.yaml
@@ -257,6 +257,10 @@
 - { name: snappy, wwwpart: gnome, setname: snappy-player }
 - { name: snappy, addflag: unclassified }
 
+- { name: snitch, wwwpart: cschreib, setname: snitch-testing }
+- { name: snitch, wwwpart: ntsecurity, setname: snitch-security }
+- { name: snitch, addflag: unclassified }
+
 - { name: snoopy, wwwpart: tuxfamily, setname: snoopy-warcraft3 }
 - { name: snoopy, wwwpart: dssz, setname: snoopy-graph-anim }
 - { name: snoopy, wwwpart: [snoopylogger,a2o], setname: snoopylogger }


### PR DESCRIPTION
A BlackArch's tool called snitch is different from the modern https://github.com/cschreib/snitch. The latter is a testing framework. The former is a security-related program, and it was removed from the upstream. The removal from BlackArch may take a while, so it's worth adding an exception here.

See https://github.com/BlackArch/blackarch/issues/3708.