### PR TITLE
Map shiftmedia forks into origins

### DIFF
--- a/800.renames-and-merges/g.yaml
+++ b/800.renames-and-merges/g.yaml
@@ -319,7 +319,7 @@
 - { setname: gnustep-talksoup,         name: talksoup }
 - { setname: gnustep-timemon,          name: timemon }
 - { setname: gnustep-volume,           name: volume-app }
-- { setname: gnutls,                   name: [gnutls-dane,gnutls-openssl,gnutls-tiny], addflavor: true }
+- { setname: gnutls,                   name: [gnutls-dane,gnutls-openssl,gnutls-tiny,shiftmedia-libgnutls], addflavor: true }
 - { setname: gnutls,                   name: [gnutls-next,gnutls-devel], weak_devel: true, nolegacy: true }
 - { setname: gnutls,                   namepat: "(?:lib)?gnutls[0-9.-]*" }
 - { setname: go-shadowsocks2,          name: [shadowsocks2, "go:shadowsocks2"] }

--- a/800.renames-and-merges/lib.yaml
+++ b/800.renames-and-merges/lib.yaml
@@ -78,7 +78,7 @@
 - { setname: libftdi,                  name: libftdi-compat }
 - { setname: libgcrypt,                namepat: "libgcrypt[0-9.-]+" }
 - { setname: libgcrypt,                name: [libgcrypt-compat,compat-libgcrypt,libgcrypt11-compat] }
-- { setname: libgcrypt,                name: [libgcrypt-static,libgcrypt-gost], addflavor: true }
+- { setname: libgcrypt,                name: [libgcrypt-static,libgcrypt-gost,shiftmedia-libgcrypt], addflavor: true }
 - { setname: libgcrypt,                name: libgcrypt15-minimal, addflavor: minimal }
 - { setname: libgda,                   name: compat-libgdata013 }
 - { setname: libgda,                   namepat: "libgda[0-9.-]*(?:-(bdb|firebird|jdbc|ldap|mdb|mysql|ui))?", addflavor: $1 }
@@ -122,6 +122,7 @@
 - { setname: libgnomeui,               name: libgnomeui-reference, addflavor: reference }
 - { setname: libgnomeuimm,             namepat: "(?:lib)?gnomeuimm[0-9.-]*" }
 - { setname: libgnt,                   name: [gnt,libgnt3] }
+- { setname: libgpg-error,             name: shiftmedia-libgpg-error, addflavor: true }
 - { setname: libgphoto2,               name: libgphoto }
 - { setname: libgpod,                  name: libgpod4 }
 - { setname: libgsf,                   name: libgsf1 }


### PR DESCRIPTION
These vcpkg packages are from forks with extra patches for building with MSVC. I expect them to lag, and there is no reason to hide it.