### PR TITLE
Remove obsolete perl:finance-quote rule

### DIFF
--- a/900.version-fixes/perl.yaml
+++ b/900.version-fixes/perl.yaml
@@ -59,7 +59,6 @@
 - { name: "perl:file-path",            ver: "2.90.0",                                      incorrect: true }
 - { name: "perl:file-rsync",           verge: "0.70",                ruleset: [alpine,slitaz], incorrect: true } # fake File-RsyncP as File-Rsync
 - { name: "perl:file-rsync",                                         ruleset: [alpine,slitaz], untrusted: true } # fake File-RsyncP as File-Rsync
-- { name: "perl:finance-quote",        verpat: "1\\.[0-9]{3}.*",                           incorrect: true }
 - { name: "perl:findbin-libs",         verge: "2.1000", verlt: "2.2100",                   sink: true }
 - { name: "perl:findbin-libs",         verpat: "2\\.[0-9]{3}.*",                           incorrect: true }
 - { name: "perl:gdgraph",              verpat: "1\\.4[34][0-9]{2}.*",                      sink: true }


### PR DESCRIPTION
Unfortunately finance-quote adopted 4 significant places on 6 May 2023. The version currently is 1.5402 which is getting marked "incorrect". It's time to retire the rule.

![image](https://user-images.githubusercontent.com/1125622/236680578-c0d68f8a-0580-4d10-a90e-dfa42fe38cb9.png)

Apparently this was briefly the case in late 2022 as well.