### PR TITLE
Add verignore for antic snapshots

### DIFF
--- a/900.version-fixes/a.yaml
+++ b/900.version-fixes/a.yaml
@@ -160,6 +160,7 @@
 - { name: ant-contrib,                                               ruleset: rpm,         untrusted: true } # accused of fake 1.0
 - { name: ant-contrib,                 verpat: ".*20[0-9]{6}",                             snapshot: true }
 - { name: anthy,                       verpat: "[0-9]+[a-z]_[0-9]+",                       snapshot: true }
+- { name: antic,                       verpat: "20[0-9][0-9].*",                           incorrect: true }
 - { name: antimicro,                   verpat: "2\\.24\\.[0-9]+",                          successor: true } # https://github.com/juliagoda/antimicro, abandoned as well
 - { name: antimicro,                   verge: "3",                                         incorrect: true } # antimicrox
 - { name: antlr,                       verpat: "20[0-9]{6}",                               incorrect: true }


### PR DESCRIPTION
MacPorts's antic is currently at "2022.11.30", which is not a tag found in the Git repository - those continue as normal with e.g. v0.2.5.