### PR TITLE
Ignore additional Gentoo metapackage categories

### DIFF
--- a/200.blacklists/metaports.yaml
+++ b/200.blacklists/metaports.yaml
@@ -4,6 +4,7 @@
 
 - { remove: true,   category: virtual, ruleset: [exherbo,gentoo] }
 - { remove: true,   category: java-virtuals, ruleset: [exherbo,gentoo] }
+- { remove: true,   category: app-alternatives, ruleset: gentoo }
 
 - { remove: true,   name: alias-font,   ruleset: freebsd }
 


### PR DESCRIPTION
Ignore the acct-* categories on Gentoo that are used to "install" user accounts, and app-alternatives that contains metapackages for switching between alternative implementations of software.

This should fix e.g. the incorrect Gentoo entry in:
https://repology.org/project/bc-unclassified