### PR TITLE
Merge eludris-cli into eludris

### DIFF
--- a/800.renames-and-merges/e.yaml
+++ b/800.renames-and-merges/e.yaml
@@ -63,7 +63,8 @@
 - { setname: elm-mua,                  name: elm-me, addflavor: me }
 - { setname: elmer,                    name: elmer-mpi, addflavor: mpi }
 - { setname: elmerfem,                 name: elmer-fem }
-- { setname: eludris,                  name: rust:eludris }
+- { setname: eludris,                  name: [rust:eludris, eludris-cli] }
+- { setname: eludris,                  name: eludris-cli-doc, addflavor: doc }
 - { setname: elvis,                    name: elvis-x11 }
 - { setname: emacs,                    name: [emacs-24bit,emacs-nox,emacs-docs,emacs-minimal,emacs-no-x-toolkit,emacs-nox-24bit,emacs-canna], addflavor: true }
 - { setname: emacs,                    name: [emacs-devel,emacs-git], weak_devel: true, nolegacy: true }


### PR DESCRIPTION
Alpine felt the need to name it `eludris-cli` despite it being the only eludris package that should exist.