### PR TITLE
Merge pinocchio

### DIFF
--- a/800.renames-and-merges/p.yaml
+++ b/800.renames-and-merges/p.yaml
@@ -147,6 +147,7 @@
 - { setname: pinball,                  name: [emilia-pinball, emilia, pinball-unofficial] }
 - { setname: pinentry,                 name: pinentry0.8 }
 - { setname: pinentry,                 name: [pinentry-gtk,pinentry-emacs,pinentry-efl], addflavor: true }
+- { setname: pinocchio,                name: python:pin }
 - { setname: pioneer,                  name: pioneerspacesim }
 - { setname: pip,                      name: ["python:pip", pip3, "python:pip-compat"] }
 - { setname: pip,                      name: ["python:pip-py27", python2-pip], addflavor: py2 }


### PR DESCRIPTION
Hi,

The https://github.com/stack-of-tasks/pinocchio project is packaged under the name `pinocchio` in multiple places (nix, aur, ros, conda, etc.), and under the name `pin` on PyPI: https://pypi.org/project/pin/


https://pypi.org/project/pinocchio was already taken and unrelated, ref. https://github.com/mkwiatkowski/pinocchio/issues/28
