### PR TITLE
Split fuse-studio from fuse

### DIFF
--- a/850.split-ambiguities/f.yaml
+++ b/850.split-ambiguities/f.yaml
@@ -169,6 +169,7 @@
 
 - { name: fuse, wwwpart: fuse-emulator, setname: fuse-emulator }
 - { name: fuse, category: [emulators,app-emulation], setname: fuse-emulator }
+- { name: fuse, wwwpart: [fuse-open.github.io,fuseopen.com], setname: fuse-studio }
 
 - { name: fxt, wwwpart: savannah, setname: fxt-tracing }
 - { name: fxt, wwwpart: jjj.de, setname: fxt-algorithms }


### PR DESCRIPTION
Homebrew's [fuse](https://formulae.brew.sh/cask/fuse) cask is actually [Fuse Studio](https://fuseopen.com/) (aka "Fuse Open" or "Fuse Fusetools"), which, according to the formula description*, is a "visual desktop tool suite for working with the Fuse framework", which in turn, according to the project website, is "an open-source cross-platform mobile app development tool suite, supporting building Android and iOS applications."

\* why doesn't the description show up in Repology, by the way?