### PR TITLE
Merge damo

### DIFF
--- a/800.renames-and-merges/d.yaml
+++ b/800.renames-and-merges/d.yaml
@@ -1,6 +1,7 @@
 # vim: tabstop=39 expandtab softtabstop=39 nomodeline
 
 - { setname: d-spy,                    name: dspy }
+- { setname: damo,                     name: "python:damo" }
 - { setname: dapl,                     name: compat-dapl }
 - { setname: dapl,                     name: dapl-debug, addflavor: true }
 - { setname: darcs,                    name: "haskell:darcs" }


### PR DESCRIPTION
It is currently showing as both "damo" and "python:damo"