### PR TITLE
Handle patch versions for x3270

### DIFF
--- a/900.version-fixes/x.yaml
+++ b/900.version-fixes/x.yaml
@@ -5,6 +5,7 @@
 - { name: x2goclient,                  verpat: ".+20[0-9]{2}.*",                           snapshot: true }
 - { name: x2vnc,                       verpat: "1\\.[0-9]{2}",                             incorrect: true } # freebsd; it's X.Y.Z, not X.YZ
 - { name: x2x,                                                                             noscheme: true } # configure says 1.30rc1, but no tags
+- { name: x3270,                       verpat: ".*ga.*",                                   any_is_patch: true }
 - { name: x64dbg,                      verpat: "20[0-9]{6}.*",                             incorrect: true } # https://github.com/x64dbg/x64dbg/releases
 - { name: x86info,                     verpat: ".*[sp].*",                                 snapshot: true } # snapshots
 - { name: x86info,                     verpat: "1\\.[0-9]+\\..*",                          incorrect: true } # snapshots


### PR DESCRIPTION
Since 3.3.9, all versions have a `ga#` suffix.

Technically any version without that suffix is incorrect since 3.3.9, but they will all be marked as older anyway after this change.