### PR TITLE
Cleanup pyside and shiboken

### DIFF
--- a/750.exceptions.yaml
+++ b/750.exceptions.yaml
@@ -59,7 +59,6 @@
 - { setname: xtrlock-pam,              name: xtrlock, wwwpart: xtrlock-pam }
 - { setname: file,                     name: "python:magic", ruleset: freebsd }
 - { setname: intel-vaapi-driver,       name: libva-intel-driver-hybrid, verge: "2.1.0" } # hybrid is up to 1.0.2
-- { setname: pyside2,                  name: pyside, verge: "5" }
 - { setname: "python:fusepy",          name: "python:fuse", wwwpart: terencehonles/fusepy }
 - { setname: keepassxc,                name: keepassx, ruleset: solus } # XXX: problem!
 - { setname: "xdrv:tdfx",              name: "xdrv:voodoo", ruleset: solus } # XXX: problem!

--- a/800.renames-and-merges/python.yaml
+++ b/800.renames-and-merges/python.yaml
@@ -291,7 +291,9 @@
 - { setname: "python:pysha3",          name: pysha3 } # CVE
 - { setname: "python:pyside",          name: pyside }
 - { setname: "python:pyside",          name: [pyside-qt4,pyside-qt4-py3], addflavor: true }
-- { setname: "python:pyside2",         name: pyside2 }
+- { setname: "python:pyside-tools",    name: pyside-tools }
+- { setname: "python:pyside2",         namepat: "(?:python:)?pyside-?2(-tools)?", addflavor: $1 }
+- { setname: "python:pyside6",         namepat: "(?:python:)?pyside-?6(-tools)?", addflavor: $1 }
 - { setname: "python:pysolar",         name: pysolar }
 - { setname: "python:pyspatialite",    name: pyspatialite } # XXX: make upstream use prefix
 - { setname: "python:pysvn",           name: pysvn }
@@ -374,7 +376,8 @@
 - { setname: "python:shiboken",        name: shiboken-qt4, addflavor: qt4 }
 - { setname: "python:shiboken",        name: "python:pyside-shiboken" }
 - { setname: "python:shiboken",        name: shiboken-py3, addflavor: py3 }
-- { setname: "python:shiboken2",       name: shiboken2 }
+- { setname: "python:shiboken2",       namepat: "(?:python:)?shiboken-?2" }
+- { setname: "python:shiboken6",       namepat: "(?:python:)?shiboken-?6" }
 - { setname: "python:shutilwhich",     name: shutilwhich }
 - { setname: "python:sip",             namepat: "sip[0-9.-]*" }
 - { setname: "python:sip",             namepat: "python:sip(?:-(?:(?:py)?qt)?)?[45][0-9.-]*" }

--- a/900.version-fixes/python.yaml
+++ b/900.version-fixes/python.yaml
@@ -129,7 +129,6 @@
 - { name: "python:pyserial",           verpat: ".*20[0-9]{6}",                             snapshot: true }
 - { name: "python:pyside",             ver: "2.0.0",                 ruleset: kaos,        incorrect: true }
 - { name: "python:pyside",             verpat: "4\\.[0-9]+_.*",                            incorrect: true } # pld
-- { name: "python:pyside2",            verge: "6",                                         incorrect: true } # pyside6, XXX: problem
 - { name: "python:pyspatialite",       ver: "3.0.1",                 noruleset: pypi,      incorrect: true } # it's 3.0.1-alpha-0
 - { name: "python:pyspatialite",       verpat: "(.*)(?:[_-]alpha[_-])(.*)",                setver: "$1alpha$2" }
 - { name: "python:pystache",           verpat: "[0-9]+(\\.[0-9]+){2}-[0-9.]+",             incorrect: true } # nix garbage

--- a/950.split-branches.yaml
+++ b/950.split-branches.yaml
@@ -302,6 +302,14 @@
 
 - { name: "python:pygobject",                             setbranchcomps: 1 }
 
+- { name: "python:pyside",   releq: "5",                  setname: "python:pyside2" }
+- { name: "python:pyside",   releq: "6",                  setname: "python:pyside6" }
+- { name: "python:pyside",   relge: "7",                  warning: "please classify me" }
+
+- { name: "python:shiboken", releq: "5",                  setname: "python:shiboken2" }
+- { name: "python:shiboken", releq: "6",                  setname: "python:shiboken6" }
+- { name: "python:shiboken", relge: "7",                  warning: "please classify me" }
+
 - { name: "python:sip",                                   setbranchcomps: 1 }
 
 - { name: "python:unit",     wwwpart: nginx,              setname: unit, addflavor: python }


### PR DESCRIPTION
Currently we have:
```
pyside-tools
pyside2-tools
pyside6
pyside6-tools
python:pyside
python:pyside-2
python:pyside-2-tools
python:pyside-6
python:pyside-tools
python:pyside2
python:pyside2-tools
python:pyside6
python:pyside6-tools
```
Some are even miscategorised (WikiData reports 6.x under `python:pyside`).

This attempts to clean them up to look like (hopefully):
```
python:pyside
python:pyside-tools (not a flavor because different version scheme)
python:pyside2 (with tools as a flavor)
python:pyside6 (with tools as a flavor)
```

Similar situation applies to `shiboken` too.

I've not figured out setting up a local environment yet, so hopefully I've not made any mistakes.