### PR TITLE
Split/merge distribution

### DIFF
--- a/800.renames-and-merges/d.yaml
+++ b/800.renames-and-merges/d.yaml
@@ -92,6 +92,7 @@
 - { setname: diskonaut,                name: "rust:diskonaut" }
 - { setname: distcc,                   name: [distcc-gnome,distcc-gtk,distcc-monitor,distcc-nozeroconf,distcc-pump,distcc-server], addflavor: true }
 - { setname: distorm,                  name: [distorm3, distorm64, "python:distorm", "python:distorm3" ] }
+- { setname: distribution-cncf,        name: docker-distribution }
 - { setname: divide-and-succeed,       name: divideandsucceed }
 - { setname: djbdns,                   name: [djbdns-djb,djbdns-ipv4], addflavor: true }
 - { setname: djview,                   name: [djview,djview-qt4,djview-qt5,djview4,djvulibre-djview4], addflavor: true } # should be merged with djvulibre or not?

--- a/850.split-ambiguities/d.yaml
+++ b/850.split-ambiguities/d.yaml
@@ -126,6 +126,10 @@
 
 - { name: disktype, wwwpart: kamwoods, setname: disktype-kamwoods } # fork
 
+- { name: distribution, wwwpart: [philovivero, time-less-ness, wizzat], setname: "python:distribution" }
+- { name: distribution, wwwpart: [docker, github.com/distribution/], setname: distribution-cncf }
+- { name: distribution, addflag: unclassified }
+
 - { name: distro-info, wwwpart: debian, setname: distro-info-debian }
 - { name: distro-info, wwwpart: etersoft, setname: distro-info-etersoft }
 - { name: distro-info, addflag: unclassified }


### PR DESCRIPTION
A couple repos referred to one project and a couple referred to another: https://repology.org/project/distribution/versions

Split parts into `python:distribution` (which has had 3 different GitHub repo owners so far, so list them all).
Split others into `distribution-cncf`.
Merge in `docker-distribution` into `distribution-cncf`.