### PR TITLE
Mark shotcut 23.07.08 and 23.07.09 as devel

### DIFF
--- a/900.version-fixes/s.yaml
+++ b/900.version-fixes/s.yaml
@@ -138,7 +138,8 @@
 - { name: shockolate,                  verlonger: 3,                 ruleset: freebsd,     incorrect: true }
 - { name: shotcut,                     verpat: "[0-9]{6,}.*",                              incorrect: true } # aur; it's not 180102, but 18.01
 - { name: shotcut,                     verpat: ".+20[0-9]{6}",                             snapshot: true } # funtoo
-- { name: shotcut,                     ver: "22.12.04",                                    devel: true, maintenance: true } # https://github.com/mltframework/shotcut/releases
+- { name: shotcut,                     ver: "23.07.08",                                    devel: true, maintenance: true } # https://github.com/mltframework/shotcut/releases
+- { name: shotcut,                     ver: "23.07.09",                                    devel: true, maintenance: true } # https://github.com/mltframework/shotcut/releases
 - { name: shotcut,                     ver: "21.04.14",                                    incorrect: true }
 - { name: shotcut,                                                   ruleset: winget,      untrusted: true } # accused of fake 21.04.14
 - { name: shotgun-debugger,            wwwpart: msarnoff,                                  successor: true }


### PR DESCRIPTION
23.07.08, which has been renamed later to 23.07.09 are pre-release
versions, mark them as such.