### PR TITLE
rename gamedev-framework into gf-gamedev-framework

### DIFF
--- a/800.renames-and-merges/g.yaml
+++ b/800.renames-and-merges/g.yaml
@@ -96,6 +96,7 @@
 - { setname: getmail,                  name: [getmail4,getmail6,"python:getmail","python:getmail6"] }
 - { setname: getopt,                   name: [gnugetopt,gnu-getopt,gnu.getopt] }
 - { setname: gexiv2,                   name: libgexiv2 }
+- { setname: gf-gamedev-framework,     name: gamedev-framework }
 - { setname: gfbgraph,                 name: libgfbgraph }
 - { setname: gfbgraph,                 namepat: "gfbgraph[0-9.-]+" }
 - { setname: gflags,                   name: [google-gflags,libgflags] }


### PR DESCRIPTION
The package can also be named gf and the split rule now renames it gf-gamedev-framework instead of simply gamedev-framework, creating two project pages. This rename merge the gamedev-framework package into gf-gamedev-framework.