### PR TITLE
vala0.54 AUR: legacy, remove teeworlds06

### DIFF
--- a/220.legacylist.yaml
+++ b/220.legacylist.yaml
@@ -2,6 +2,6 @@
 
 - { name: ruby-mini_magick-4.5, ruleset: aur, legacy: true }
 - { name: ruby-slack-notifier-1, ruleset: aur, legacy: true }
-- { name: teeworlds06, ruleset: aur, legacy: true }
 - { name: vala0.44, ruleset: aur, legacy: true }
+- { name: vala0.54, ruleset: aur, legacy: true }
 - { name: boost174, ruleset: aur, legacy: true }


### PR DESCRIPTION
`vala0.54` https://aur.archlinux.org/packages/vala0.54 will build 0.54.x only, at the moment is listed as old instead of legacy


`teeworlds06` have been deleted 2 years ago

https://lists.archlinux.org/archives/list/aur-requests@lists.archlinux.org/thread/527SVP4KE2TNHSJAYSJDILSP3FUWXM6J/#VWSKKPMQTVDX3MTR5245TMQMQZT6SLPP