### PR TITLE
cinema-artemanufrij is playmyvideos

### DIFF
--- a/850.split-ambiguities/c.yaml
+++ b/850.split-ambiguities/c.yaml
@@ -162,7 +162,7 @@
 - { name: cinder, addflag: unclassified }
 
 - { name: cinema, wwwpart: maui, setname: maui-clip }
-- { name: cinema, wwwpart: artemanufrij, setname: cinema-artemanufrij }
+- { name: cinema, wwwpart: artemanufrij, setname: playmyvideos }
 - { name: cinema, addflag: unclassified }
 
 - { name: clementine,                  setname: clementine-player                            } # clementine player vs. window manager


### PR DESCRIPTION
Hi, `cinema-artemanufrij` is `playmyvideos`

* https://anufrij.org/cinema/
* https://github.com/artemanufrij/playmyvideos
* https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=playmyvideos
* https://repology.org/project/playmyvideos/versions
* https://repology.org/project/cinema-artemanufrij/versions

In the same way as `melody` from the same developer is `playmymusic`

```
- { name: melody, wwwpart: yoav-lavi, setname: melody-regexp-lang }
- { name: melody, wwwpart: anufrij, setname: playmymusic }
- { name: melody, addflag: unclassified }
```