### PR TITLE
Fix upstream url for snitch testing lib

### DIFF
--- a/850.split-ambiguities/s.yaml
+++ b/850.split-ambiguities/s.yaml
@@ -279,7 +279,7 @@
 - { name: snappy, wwwpart: gnome, setname: snappy-player }
 - { name: snappy, addflag: unclassified }
 
-- { name: snitch, wwwpart: cschreib, setname: snitch-testing }
+- { name: snitch, wwwpart: snitch-org, setname: snitch-testing }
 - { name: snitch, wwwpart: ntsecurity, setname: snitch-security }
 - { name: snitch, addflag: unclassified }
 


### PR DESCRIPTION
Weeell, it actually moved :)

See #679, https://github.com/snitch-org/snitch, https://repology.org/project/snitch-unclassified.