### PR TITLE
renames & merges: add bitcoin-util

### DIFF
--- a/800.renames-and-merges/b.yaml
+++ b/800.renames-and-merges/b.yaml
@@ -93,7 +93,7 @@
 - { setname: bison,                    name: [bison-doc,bison-runtime], addflavor: true }
 - { setname: bison,                    name: [bison2,bison27] }
 - { setname: bisonc++,                 name: bisoncpp }
-- { setname: bitcoin,                  name: [bitcoin-cli,bitcoin-core,bitcoin-daemon,bitcoin-gui,bitcoin-qt,bitcoin-tx,bitcoin-utils,bitcoind,bitcoinqt], addflavor: true }
+- { setname: bitcoin,                  name: [bitcoin-cli,bitcoin-core,bitcoin-daemon,bitcoin-gui,bitcoin-qt,bitcoin-tx,bitcoin-util,bitcoin-utils,bitcoind,bitcoinqt], addflavor: true }
 - { setname: bitdefender,              name: bdc, ruleset: openpkg }
 - { setname: bitkeeper,                name: bitkeeper-development, weak_devel: true, nolegacy: true }
 - { setname: bitkeeper,                name: bitkeeper-production }


### PR DESCRIPTION
This binary is also shipped with Bitcoin Core. I assume `bitcoin-utils` is in here (and should remain) because some packagers are shipping the collections of "`bitcoin-cli`, `bitcoin-tx`, `bitcoin-wallet` & `bitcoin-util`" as `bitcoin-utils`.