### PR TITLE
There is no pdf2svg 1.0; 0.2.3 is still current

### DIFF
--- a/900.version-fixes/p.yaml
+++ b/900.version-fixes/p.yaml
@@ -82,6 +82,8 @@
 - { name: pcsx2,                       verpat: "[0-9a-f]{7}.*",                            incorrect: true }
 - { name: pcsxr,                       verpat: ".+20[0-9]{6}",                             snapshot: true }
 - { name: pdf2svg,                     verpat: "20[0-9]{6}",                               snapshot: true }
+- { name: pdf2svg,                     ver: "1.0",                   ruleset: scoop,       incorrect: true }
+- { name: pdf2svg,                                                   ruleset: scoop,       untrusted: true } # accused of fake 1.0
 - { name: pdf4tcl,                     verpat: "[0-9]+",                                   incorrect: true } # 0.9.2, not 092
 - { name: pdfbook,                                                                         noscheme: true }
 - { name: pdfminer,                    vergt: "20140328",                                  snapshot: true, maintenance: true } # https://pypi.org/project/pdfminer/#history


### PR DESCRIPTION
https://repology.org/project/pdf2svg/versions shows pdf2svg 1.0 being current (as claimed by Scoop), but according to the pdf2svg project - https://github.com/dawbarton/pdf2svg - the current version is 0.2.3.