### PR TITLE
Merge dhall

### DIFF
--- a/800.renames-and-merges/d.yaml
+++ b/800.renames-and-merges/d.yaml
@@ -66,6 +66,7 @@
 - { setname: dfrs,                     name: "rust:dfrs" }
 - { setname: dftd4,                    name: "python:$0" }
 - { setname: dgen-sdl,                 name: dgen }
+- { setname: dhall,                    name: "haskell:dhall" }
 - { setname: dhcp,                     name: [dhclient,isc-dhclient,isc-dhcp], addflavor: client }
 - { setname: dhcp,                     name: [isc-dhcpd], addflavor: server }
 - { setname: dhcp,                     name: [isc-dhcrelay], addflavor: relay }


### PR DESCRIPTION
https://packages.debian.org/sid/dhall official implementation of https://dhall-lang.org/.

Merging `haskell:dhall` to `dhall` because it is a CLI tool (although it also provides a Haskell library).