### PR TITLE
rimgo: marked date verpat as incorrect

### DIFF
--- a/900.version-fixes/r.yaml
+++ b/900.version-fixes/r.yaml
@@ -96,6 +96,7 @@
 - { name: rime-quick,                                                                      noscheme: true }
 - { name: rime-wubi,                                                                       noscheme: true }
 - { name: rime-wugniu,                                                                     noscheme: true }
+- { name: rimgo,                       verpat: "20[0-9]{2}\\.[0-9]{2}\\.[0-9]{2}",         incorrect: true }
 - { name: rinetd,                      ver: "0.62.1sam",                                   ignore: true } # debian garbage
 - { name: rinetd,                                                    ruleset: debuntu,     untrusted: true }
 - { name: rinetd,                      ver: "0.64",                  ruleset: aur,         incorrect: true }


### PR DESCRIPTION
Should fix the `2022.04.22` version from the AUR being marked as newer than `1.2.1`.