### PR TITLE
Merge quodlibet flavours

### DIFF
--- a/800.renames-and-merges/q.yaml
+++ b/800.renames-and-merges/q.yaml
@@ -66,6 +66,8 @@
 - { setname: quazip,                   name: [quazip1,quazip-legacy] }
 - { setname: quesoglc,                 name: libglc }
 - { setname: quiterss,                 name: quiterss-qt4, addflavor: true }
+- { setname: quodlibet,                name: [quodlibet-full,quodlibet-without-gst-plugins,quodlibet-xine,quodlibet-xine-full], addflavor: true }
+- { setname: quodlibet,                name: python:$0 }
 - { setname: quota,                    name: quota-tools }
 - { setname: qutebrowser,              name: [qutebrowser-qt5, qutebrowser-bin, qutebrowser-not-only-latin ], addflavor: true }
 - { setname: qutebrowser,              name: python:$0 }


### PR DESCRIPTION
https://repology.org/projects/?search=quodlibet

Hello

nixpkgs have some variations of quodlibet

plus for FreeBSD is listed as [python:quodlibet](https://repology.org/project/python:quodlibet/versions) for that I have added `python:$0` which I ripped off qutebrowser which is in same q.yml, seems to be the change needed