### PR TITLE
Merge xdriver_xf86 into xdrv

### DIFF
--- a/500.wildcard.yaml
+++ b/500.wildcard.yaml
@@ -256,5 +256,5 @@
 - { setname: "xemacs:$0", addflag: wconce, noflag: [wconce,not_wildcard,not_xemacs], category: app-xemacs, ruleset: [gentoo, exherbo] }
 
 # Xorg drivers
-- { setname: "xdrv:$1", addflag: wconce, noflag: [wconce,not_wildcard,not_xorg], namepat: "(?:xf86|xorg|xserver-xorg|x11-driver|xorg-xf86|xorg-driver)-(?:input-|video-)(.*?)" }
+- { setname: "xdrv:$1", addflag: wconce, noflag: [wconce,not_wildcard,not_xorg], namepat: "(?:xf86|xdriver-xf86|xorg|xserver-xorg|x11-driver|xorg-xf86|xorg-driver)-(?:input-|video-)(.*?)" }
 - { setname: "xdrv:$1", addflag: wconce, noflag: [wconce,not_wildcard,not_xorg], namepat: "xorg(?:-x11)?-drv-(.*)" }


### PR DESCRIPTION
Hello, this should merge Buildroot `xdriver_xf86` into `xdrv:$1`

https://repology.org/projects/?search=xdriver_xf86

First spotted by `xdriver-xf86-video-amdgpu` vs `xdrv:amdgpu`

https://repology.org/projects/?search=amdgpu&maintainer=&category=&inrepo=&notinrepo=&repos=&families=&repos_newest=&families_newest=