### PR TITLE
Extend merge amdvlk

### DIFF
--- a/800.renames-and-merges/a.yaml
+++ b/800.renames-and-merges/a.yaml
@@ -127,7 +127,8 @@
 - { setname: amazon-ecr-credential-helper, name: [docker-credential-helper-ecr,docker-credential-ecr-login] }
 - { setname: amber-search,             name: "rust:amber" }
 - { setname: amd-app-sdk,              name: amdapp-sdk }
-- { setname: amdvlk,                   name: amdvlk-vulkan-driver }
+- { setname: amdvlk,                   name: [amdvlk-vulkan-driver,vulkan-amdgpu,amdvlk-2021q2.5,amdvlk-2023q3.3] }
+- { setname: amdvlk,                   name: amdvlk-debug, addflavor: true }
 - { setname: ammonite,                 name: ammonite-repl }
 - { setname: amp-editor,               name: "rust:amp" }
 - { setname: ampy,                     name: ["python:adafruit-ampy","python:ampy",adafruit-ampy], wwwpart: adafruit }


### PR DESCRIPTION
Hello,

This merge ALT Linux `vulkan-amdgpu` into the common name `amdvlk`, this is the "AMD Open Source Driver For Vulkan" developed at https://github.com/GPUOpen-Drivers/AMDVLK

https://repology.org/project/vulkan-amdgpu/versions

ALT Linux spec https://packages.altlinux.org/en/sisyphus/srpms/vulkan-amdgpu/

Arch Linux amdvlk https://gitlab.archlinux.org/archlinux/packaging/packages/amdvlk/-/blob/main/PKGBUILD?ref_type=heads

***

And merge 3 variations on AUR, 2 of which are legacy versions, is the correct procedure for them?

https://repology.org/projects/?search=amdvlk