### PR TITLE
Extend merge widevine

### DIFF
--- a/800.renames-and-merges/w.yaml
+++ b/800.renames-and-merges/w.yaml
@@ -43,7 +43,7 @@
 - { setname: white-dune,               name: whitedune }
 - { setname: whizzytex,                name: tex-whizzytex }
 - { setname: wicd,                     name: [wicd-gtk,wicd-patched], addflavor: true }
-- { setname: widevine,                 name: [chromium-plugin-widevinecdm,chromium-stable-widevine-plugin,chromium-widevine,inox-widevine-plugin,qt5-webengine-widevine,qtwebengine-widevine,vivaldi-widevine,widevine-armv7h], addflavor: true }
+- { setname: widevine,                 name: [chromium-plugin-widevinecdm,chromium-stable-widevine-plugin,chromium-widevine,qt5-webengine-widevine,qtwebengine-widevine,vivaldi-widevine,widevine-armv7h,widevine-cdm,linux-widevine-cdm,qt6-webengine-widevine], addflavor: true }
 - { setname: wiimms-iso-tools,         name: wiimms }
 - { setname: wiiuse,                   name: libwiiuse0 }
 - { setname: wildfly,                  namepat: "wildfly[0-9.-]+" }


### PR DESCRIPTION
Hello

* https://repology.org/projects/?search=widevine

merge widevine from FreeBSD Port (linux-widevine-cdm), Nixpkgs (widevine-cdm), AUR qt6-webengine plugin (qt6-webengine-widevine)

Remove the rule for Inox browser (inox-widevine-plugin) which is no longer present in any repo (no longer developed since 2019)

On https://repology.org/projects/?search=widevine is listed a `widevine-installer` from Fedora (more likely a script?) but don't seem exist anymore on https://packages.fedoraproject.org/search?query=widevine ?