### PR TITLE
Merge libsass-python into python-libsass

### DIFF
--- a/800.renames-and-merges/python.yaml
+++ b/800.renames-and-merges/python.yaml
@@ -139,6 +139,7 @@
 - { setname: "python:lark-parser",     name: "python:lark", addflavor: lark } # both present on pypi from same author referencing the same upstream; XXX: upstream error
 - { setname: "python:lektor",          name: lektor }
 - { setname: "python:lhafile",         name: "python:python-lhafile" }
+- { setname: "python:libsass",         name: libsass-python }
 - { setname: "python:libvirt-python",  name: ["python:libvirt", libvirt-python ] }
 - { setname: "python:libvirt-python",  name: [libvirt-python2, libvirt-python3], addflavor: true }
 - { setname: "python:logzero",         name: logzero }


### PR DESCRIPTION
https://repology.org/projects/?search=libsass

https://repology.org/project/libsass-python/versions

https://github.com/sass/libsass-python

Hello, Debian and derivates are using upstream repository name while all the other are using `python-libsass`