### PR TITLE
Go wildcard for GNU Guix

### DIFF
--- a/500.wildcard.yaml
+++ b/500.wildcard.yaml
@@ -70,6 +70,7 @@
 # Go
 - { setname: "go:$0", addflag: wconce, noflag: [wconce,not_wildcard,not_go], ruleset: gentoo, category: dev-go }
 - { setname: "go:$1", addflag: wconce, noflag: [wconce,not_wildcard,not_go], namepat: "go-(.*)" }
+- { setname: "go:$1", addflag: wconce, noflag: [wconce,not_wildcard,not_go], namepat: "go-github-com-(.*)" }
 - { setname: "go:$1", addflag: wconce, noflag: [wconce,not_wildcard,not_go], namepat: "golang-(.*)" }
 
 # GStreamer


### PR DESCRIPTION
Hello, not sure if this is correct

With a generic search for `libsass`  https://repology.org/projects/?search=libsass

There are `go:github-bep-golibsass` for Fedora and DeBuntu and `go:github-com-bep-golibsass` for GNU Guix

* https://repology.org/project/go:github-bep-golibsass/versions
* https://repology.org/project/go:github-com-bep-golibsass/versions

Upstream is the same https://github.com/bep/golibsass https://github.com/bep/golibsass/tags

Searching for `github-com` https://repology.org/projects/..go:github-com-biogo-store-step/?search=github-com

There are many results for not normalized Go modules from GNU Guix