### PR TITLE
Merge go:github-wellington-libsass into go:github-wellington-go-libsass

### DIFF
--- a/800.renames-and-merges/go.yaml
+++ b/800.renames-and-merges/go.yaml
@@ -5,6 +5,7 @@
 - { setname: "go:github-go-macaron-macaron", name: ["go:github-macaron-v1", "go:gopkg-macaron-1"] }
 - { setname: "go:github-miekg-mmark",  name: ["go:mmark",mmark] }
 - { setname: "go:github-rakyll-statik", name: ["go:statik"] }
+- { setname: "go:github-wellington-go-libsass", name: "go:github-wellington-libsass" }
 - { setname: "go:gopkg-sourcemap",     name: "go:gopkg-sourcemap-1" }
 - { setname: "go:gorm",                name: "go:github-jinzhu-gorm" }
 - { setname: "go:goversion",           name: goversion }


### PR DESCRIPTION
Hello,

https://repology.org/projects/?search=libsass&maintainer=&category=&inrepo=&notinrepo=&repos=&families=&repos_newest=&families_newest=

Merge `go:github-wellington-libsass` into `go:github-wellington-go-libsass`

Upstream repo is https://github.com/wellington/go-libsass