### PR TITLE
Split g-ls packages from ambiguities

### DIFF
--- a/850.split-ambiguities/g.yaml
+++ b/850.split-ambiguities/g.yaml
@@ -1,5 +1,9 @@
 # vim: tabstop=29 expandtab softtabstop=29 nomodeline
 
+- { name: g, wwwpart: equationzhao, setname: g-ls }
+- { name: g, wwwpart: knu, setname: g-grep-wrapper }
+- { name: g, addflag: unclassified }
+
 - { name: g2, wwwpart: orefalo, setname: g2-git }
 # otherwise, graphics library
 


### PR DESCRIPTION
Recently, [`g-ls`](https://github.com/Equationzhao/g) was added to MacPorts, and was wrongfully categories under `g`, which includes another project with a different function.

This should split and resolve any ambiguities between `g` (the category) and `g` (the MacPorts package, which refers to the `g-ls` project) as it's the official package name adopted widely by various package managers (most notably, Homebrew and AUR) and used officially by the creator, in relation to Repology.