### PR TITLE
Disambiguate noson vs. noson-app

### DIFF
--- a/850.split-ambiguities/n.yaml
+++ b/850.split-ambiguities/n.yaml
@@ -108,6 +108,8 @@
 - { name: nonpareil, wwwpart: enve-omics, setname: nonpareil-metagenomic-coverage }
 - { name: nonpareil, addflag: unclassified }
 
+- { name: noson, verge: '5', setname: noson-app } # noson = lib, noson-app = program, nixpkgs ignored "-app"
+
 - { name: nostromo, wwwpart: nazgul.ch, setname: nostromo-httpd }
 - { name: nostromo, wwwpart: nostromo.sh, setname: nostromo-aliases-cli }
 - { name: nostromo, addflag: unclassified }


### PR DESCRIPTION
https://github.com/janbar/noson is the library used by
https://github.com/janbar/noson-app Qt5 GUI program.

All packages on repology stick this naming scheme except for nixpkgs
calling the GUI just noson, thus falsely marking all other noson library
packages out of date (noson-app 5.6.5 vs. noson 2.12.6).