### PR TITLE
Add version ignore and untrusted for tinyxml

### DIFF
--- a/900.version-fixes/t.yaml
+++ b/900.version-fixes/t.yaml
@@ -139,6 +139,8 @@
 - { name: tinyxml,                     verpat: "2-.*",                                     incorrect: true } # nix
 - { name: tinyxml,                     ver: "2.6.2_2",               ruleset: buildroot,   incorrect: true }
 - { name: tinyxml,                                                   ruleset: buildroot,   untrusted: true } # accused of fake 2.6.2_2
+- { name: tinyxml,                     ver: "10.0.0",                                      incorrect: true } # tinyxml2
+- { name: tinyxml,                                                   ruleset: wikidata,    untrusted: true } # wikidata reports version from tinyxml2 instead
 - { name: tivodecode,                  ver: "0.2",                   ruleset: fedora,      incorrect: true }
 - { name: tivodecode,                                                ruleset: fedora,      untrusted: true }
 - { name: tk,                          verpat: ".*a[0-9]+",                                devel: true }


### PR DESCRIPTION
The wikidata version for "tinyxml" is actually "tinyxml2". I see related comments about this in https://repology.org/project/tinyxml/report, here's a pull request.

Based on https://github.com/repology/repology-rules?tab=readme-ov-file#rule-syntax I think this is the proper fix but please advise if it's not.

Thanks!