### PR TITLE
c.yaml: merge cargo-auditable package names into one

### DIFF
--- a/800.renames-and-merges/c.yaml
+++ b/800.renames-and-merges/c.yaml
@@ -46,6 +46,7 @@
 - { setname: cargo,                    name: [cargo-completion,cargo-standalone,cargo-bootstrap,cargo-stage1], addflavor: true }
 - { setname: cargo,                    name: cargo-nightly, weak_devel: true, nolegacy: true }
 - { setname: cargo-audit,              name: ["rust:cargo-audit",rust-cargo-audit] }
+- { setname: cargo-auditable,          name: ["rust:cargo-auditable",rust-cargo-auditable] }
 - { setname: cargo-bloat,              name: ["rust:cargo-bloat",rust-cargo-bloat] }
 - { setname: cargo-c,                  name: "rust:cargo-c" }
 - { setname: cargo-deb,                name: "rust:cargo-deb" }

--- a/800.renames-and-merges/c.yaml
+++ b/800.renames-and-merges/c.yaml
@@ -46,7 +46,7 @@
 - { setname: cargo,                    name: [cargo-completion,cargo-standalone,cargo-bootstrap,cargo-stage1], addflavor: true }
 - { setname: cargo,                    name: cargo-nightly, weak_devel: true, nolegacy: true }
 - { setname: cargo-audit,              name: ["rust:cargo-audit",rust-cargo-audit] }
-- { setname: cargo-auditable,          name: ["rust:cargo-auditable",rust-cargo-auditable] }
+- { setname: cargo-auditable,          name: rust:$0 }
 - { setname: cargo-bloat,              name: ["rust:cargo-bloat",rust-cargo-bloat] }
 - { setname: cargo-c,                  name: "rust:cargo-c" }
 - { setname: cargo-deb,                name: "rust:cargo-deb" }


### PR DESCRIPTION
This merges various names of my project, https://github.com/rust-secure-code/cargo-auditable

The names currently in use can be found [here](https://repology.org/projects/?search=cargo-auditable) so you can double-check my edit.

Thanks!