### PR TITLE
Merge ldid (from ProcursusTeam)

### DIFF
--- a/800.renames-and-merges/l.yaml
+++ b/800.renames-and-merges/l.yaml
@@ -39,6 +39,7 @@
 - { setname: lcms,                     name: [lcms,lcms1,lcms2,little-cms,little-cms2,lcms-python,liblcms,liblcms2,littlecms] }
 - { setname: ldb,                      namepat: "(?:lib)?ldb[0-9]*" }
 - { setname: ldc,                      name: liblphobos, addflavor: true }
+- { setname: ldid,                     name: ldid-procursus, wwwpart: ProcursusTeam }
 - { setname: ldns,                     name: "perl:dns-ldns", wwwpart: nlnetlabs, addflavor: perl } # part of
 - { setname: ldns,                     name: "python:ldns", addflavor: python }
 - { setname: ldns,                     name: [ldns-tools,ldns-utils] }


### PR DESCRIPTION
[The Procursus Team](https://github.com/ProcursusTeam) maintains a fork of an original project named ldid as `ldid-procursus`. In Repology, some entries within the `ldid` project aim to the version scheme used by the Procursus Team (causing them to appear to be outdated). 

Instead, these entries (notably from the AUR), now or in the future (from other package managers), are to be considered part of the `ldid-procursus` project.