### PR TITLE
Merge lv2-airwindows into airwindows-lv2

### DIFF
--- a/800.renames-and-merges/lv2.yaml
+++ b/800.renames-and-merges/lv2.yaml
@@ -1,5 +1,6 @@
 # vim: tabstop=39 expandtab softtabstop=39 nomodeline
 
+- { setname: "lv2:airwindows",         name: [airwindows-lv2,lv2-airwindows] }
 - { setname: "lv2:gxplugins",          name: [gxplugins-lv2,gxplugins.lv2] }
 - { setname: "lv2:noise-repellent",    name: [noise-repellent,noise-repellent-lv2] }
 - { setname: "lv2:swh",                name: [lv2-swh,lv2-swh-plugins,swh-lv2,swh-plugins-lv2] }


### PR DESCRIPTION
This merge is required because the package name is `lv2-airwindows` in openSUSE: https://build.opensuse.org/package/show/openSUSE:Factory/lv2-airwindows