### PR TITLE
Update ruff package homepage

### DIFF
--- a/850.split-ambiguities/r.yaml
+++ b/850.split-ambiguities/r.yaml
@@ -182,7 +182,7 @@
 
 - { name: "ruby:rash", setname: "ruby:rash-alt", ruleset: sisyphus } # fork
 
-- { name: ruff, wwwpart: [ruff.rs,astral-sh], setname: ruff-python-linter }
+- { name: ruff, wwwpart: [ruff.rs,astral-sh,astral.sh], setname: ruff-python-linter }
 - { name: ruff, wwwpart: magicsplat, setname: ruff-docs-generator }
 - { name: ruff, addflag: unclassified }
 


### PR DESCRIPTION
[`ruff`](https://github.com/astral-sh/ruff) has a new established homepage that many package mangers have adopted. This change allows Repology to correctly categorize packages with the new homepage.

I thought the best approach was to use the following below mostly since there's the ruff repo (from github[dot]com, which would match with `astral-sh`) and the ruff homepage (which would match with `astral.sh`)

```yaml
- { name: ruff, wwwpart: ruff.rs, wwwpat: astral(\\-|\\.)sh, setname: ruff-python-linter }
```

However, I'm unaware of the complications between using both `wwwpart` and `wwwpat`, so just appending to the new homepage to `wwwpart` should do the trick.