### PR TITLE
Fix Anope 2.1 not being marked as a development release.

### DIFF
--- a/900.version-fixes/a.yaml
+++ b/900.version-fixes/a.yaml
@@ -165,6 +165,7 @@
 - { name: android-tools,               verpat: "20[0-9]{6}.*",                             snapshot: true }
 - { name: android-tools,               ver: "21",                                          sink: true } # debian oldstable, assuming ancient version
 - { name: anki,                        ver: "2.1.0",                 ruleset: debuntu,     ignore: true } # fake
+- { name: anope,                       verpat: "2\\.1\\.[0-9]+",                           devel: true }
 - { name: ansible-runner,              verpat: ".*[ab].*",                                 devel: true }
 - { name: ant-contrib,                 ver: "1.0",                   ruleset: rpm,         incorrect: true }
 - { name: ant-contrib,                                               ruleset: rpm,         untrusted: true } # accused of fake 1.0

--- a/900.version-fixes/a.yaml
+++ b/900.version-fixes/a.yaml
@@ -165,7 +165,7 @@
 - { name: android-tools,               verpat: "20[0-9]{6}.*",                             snapshot: true }
 - { name: android-tools,               ver: "21",                                          sink: true } # debian oldstable, assuming ancient version
 - { name: anki,                        ver: "2.1.0",                 ruleset: debuntu,     ignore: true } # fake
-- { name: anope,                       verpat: "2\\.1\\.[0-9]+",                           devel: true }
+- { name: anope,                       verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
 - { name: ansible-runner,              verpat: ".*[ab].*",                                 devel: true }
 - { name: ant-contrib,                 ver: "1.0",                   ruleset: rpm,         incorrect: true }
 - { name: ant-contrib,                                               ruleset: rpm,         untrusted: true } # accused of fake 1.0


### PR DESCRIPTION
Anope has a stable branch (2.0) and a development branch (2.1). Fedora (and its descendants) decided to ship the development branch for some reason. This has resulted in Repology marking distributions that ship the stable version as out of date.