### PR TITLE
Merge swiftlang

### DIFF
--- a/800.renames-and-merges/s.yaml
+++ b/800.renames-and-merges/s.yaml
@@ -422,7 +422,7 @@
 - { setname: swift,                    name: swift-bin, addflavor: bin }
 - { setname: swift,                    name: swift4 }
 - { setname: swift,                    name: swiften, addflavor: true }
-- { setname: swift,                    name: swift-language }
+- { setname: swift,                    name: [swift-language,swiftlang] }
 - { setname: swig,                     namepat: "swig[0-9]*-(.*)", ruleset: macports, addflavor: $1 } # split by supported language
 - { setname: swig,                     namepat: "swig[0-9.-]+" }
 - { setname: swissfileknife,           name: sfk }


### PR DESCRIPTION
Debian has packaged swift-lang using the source package name [swiftlang](https://tracker.debian.org/pkg/swiftlang).

This is untested and I'm unsure if it's the right fix. Note that 850.split-amgibuities/s.yaml renames swift to swift-lang if there is a URL containing swift.org which the Debian package should have. So it's unclear whether it is better to just set the correct name (swift-name) directly and on the previous line for swift-language or set it to swift and let the ambiguity rule handle it afterwards.