### PR TITLE
Merge rsms-inter-fonts

### DIFF
--- a/800.renames-and-merges/fonts/i.yaml
+++ b/800.renames-and-merges/fonts/i.yaml
@@ -90,6 +90,7 @@
     - interui-otf
     - interui-ttf-hinted
     - otf-inter
+    - rsms-inter-fonts
     - ttf-inter
     - inter-font-unhinted
     - ttf-inter-ui


### PR DESCRIPTION
Fedora packages fonts-inter as rsms-inter-fonts