### PR TITLE
Merge musepack, libmpc-musepack and libmpcdec

### DIFF
--- a/800.renames-and-merges/m.yaml
+++ b/800.renames-and-merges/m.yaml
@@ -335,7 +335,7 @@
 - { setname: munt,                     name: [munt-alsadrv, munt-mt32emu-alsadrv], addflavor: alsadrv }
 - { setname: muparser,                 namepat: "libmuparser[0-9.-]*" }
 - { setname: mupdf,                    name: [libmupdf,mupdf-nojs,mupdf-seccomp,mupdf-tools], addflavor: true }
-- { setname: musepack,                 name: [musepack-tools,libmusepack], addflavor: true }
+- { setname: musepack,                 name: [musepack-tools,libmusepack,libmpcdec], addflavor: true }
 - { setname: musescore,                name: mscore } # XXX: problem?
 - { setname: musescore,                name: [musescore-dev,musescore-snapshot,musescore3-nightly,musescore-nightly], weak_devel: true, nolegacy: true }
 - { setname: musescore,                name: [musescore-legacy,musescore.3,musescore3,musescore2] }

--- a/850.split-ambiguities/l.yaml
+++ b/850.split-ambiguities/l.yaml
@@ -93,7 +93,7 @@
 - { name: libmpack, ruleset: solus, setname: "lua:mpack" }
 
 - { name: libmpc, wwwpart: multiprecision, setname: gnumpc }
-- { name: libmpc, wwwpart: musepack, setname: libmpc-musepack }
+- { name: libmpc, wwwpart: musepack, setname: musepack }
 - { name: libmpc, addflag: unclassified }
 
 - { name: libopenaptx, wwwpart: arkq, setname: $0-arkq }


### PR DESCRIPTION
Actually all of them build from the same source:
https://www.musepack.net/index.php?pg=src

Arch Linux (musepack):
https://gitlab.archlinux.org/archlinux/packaging/packages/musepack/-/blob/main/PKGBUILD#L15

Fedora (libmpcdec):
https://src.fedoraproject.org/rpms/libmpcdec/blob/rawhide/f/libmpcdec.spec#_16

Debian (libmpc-musepack):
https://salsa.debian.org/multimedia-team/libmpc/-/blob/master/debian/watch#L3