### PR TITLE
Merge gnome-games-app with gnome-games

### DIFF
--- a/800.renames-and-merges/g.yaml
+++ b/800.renames-and-merges/g.yaml
@@ -252,6 +252,7 @@
 - { setname: gnome-desktop,            name: gnome-desktop-reference, addflavor: reference }
 - { setname: gnome-desktop-sharp,      name: gnome-desktop-sharp2 }
 - { setname: gnome-feeds,              name: gfeeds }
+- { setname: gnome-games,              name: gnome-games-app }
 - { setname: gnome-keyring,            name: gnome-keyring3 }
 - { setname: gnome-klotski,            name: klotski }
 - { setname: gnome-latex,              name: latexila } # renamed


### PR DESCRIPTION
gnome-games-app is a Debian-specific name of this app.