### PR TITLE
Rename emulationstation-de to es-de

### DIFF
--- a/800.renames-and-merges/e.yaml
+++ b/800.renames-and-merges/e.yaml
@@ -137,6 +137,7 @@
 - { setname: "erlang:cl",              name: cl }
 - { setname: "erlang:esdl",            name: ["erlang:sdl",esdl] }
 - { setname: es,                       name: es-shell }
+- { setname: es-de,                    name: emulationstation-de }
 - { setname: esbuild,                  name: "go:github-evanw-esbuild" }
 - { setname: espanso,                  name: [espanso-wayland, espanso-x11], addflavor: true }
 - { setname: espanso,                  name: espanso-pre, weak_devel: true, nolegacy: true }


### PR DESCRIPTION
According to the upstream FAQ
(https://gitlab.com/es-de/emulationstation-de/-/blob/master/FAQ.md):

“As of the 3.0.0 release the official name for the project and application is ES-DE Frontend or simply ES-DE.”