### PR TITLE
Add verignore for fte

### DIFF
--- a/900.version-fixes/f.yaml
+++ b/900.version-fixes/f.yaml
@@ -324,6 +324,7 @@
 - { name: fstrcmp,                     verpat: "[0-9]+\\.[0-9]+\\.D[0-9]+",                any_is_patch: true }
 - { name: fstrcmp,                     verpat: "[0-9]+\\.[0-9]+\\.[0-9]+",                 incorrect: true }
 - { name: fswebcam,                    vergt: "20140113",            ruleset: sisyphus,    snapshot: true } # https://www.sanslogic.co.uk/fswebcam/
+- { name: fte,                         verpat: "[0-9]{8}",                                 altscheme: true } # sourceforge publish date
 - { name: ftgl,                        ver: "2.1.3",                 ruleset: [gobolinux,mageia,openmandriva,pclinuxos,pld], incorrect: true } # it's 2.1.3-rc5
 - { name: ftgl,                                                      ruleset: [gobolinux,mageia,openmandriva,pclinuxos,pld], untrusted: true } # accused of fake 2.1.3
 - { name: ftgl,                        ver: "2.1.3",                                       untrusted: true } # new official release is unlikely


### PR DESCRIPTION
The version of fte is not `20110708` but `0.50.2`, however there is a confusion which the sourceforge archive that has the upload date. The version can be found within the common archive, inside the `NEWS` file:

```
$ cat NEWS
Revision history
-----------------------------------------------------------------------
0.50.2b6 -- <fill month here> 2011
  + Allow \r at the end-of-line when looking for the end-of-heredoc in
    Perl hilighting mode to make it easier to read files created on windows
    and transfered to unix incorrectly.
  + Add ShowTildeFilesInDirList global config option to allow hiding
    of *~ in the directory list (most of the time, I don't want this)
    default is true.
  ! Allow open-brace on same line as function name in shell mode
  + Added permission flags to the directory listings on unix to show rwx
    at a glance - makes it easier to debug certain issues, know if you
    can write to the file, etc.
  ! Compilation fixes for Windows compilers
  + Allow JAVA colorizer to be used for javascript files (.js)
  - Ongoing conversion of return codes to return consistently
    1 for success or 0 for failure
  ! Colorizing man pages again (using MAN_KEEP_FORMATTING)
  + adding 2nd FD for WaitFdPipeEvent() so used in con_linux.cpp

0.50.2b5 -- March 2010
  + Allowed -m flag to take lower-cased version of mode names
  ! .t files are perl test files, added.
...
```