### PR TITLE
Use common name for Sherlock Project

### DIFF
--- a/850.split-ambiguities/s.yaml
+++ b/850.split-ambiguities/s.yaml
@@ -152,7 +152,7 @@
 - { name: shed, addflag: unclassified }
 
 - { name: sherlock, wwwpart: open-music-kontrollers, setname: lv2:sherlock }
-- { name: sherlock, wwwpart: sherlock-project, setname: sherlock-social-osint }
+- { name: sherlock, wwwpart: sherlock-project, setname: sherlock-project }
 - { name: sherlock, wwwpart: sergius02, setname: sherlock-ip-info }
 - { name: sherlock, addflag: unclassified }
 


### PR DESCRIPTION
The common and recognized name for Sherlock is either Sherlock or Sherlock project.
This PR should just fix the prior ambiguity split's name of sherlock-social-osint.