### PR TITLE
Fix pattern escape errors on make check

### DIFF
--- a/scripts/check.py
+++ b/scripts/check.py
@@ -336,13 +336,13 @@ schema = Schema(
 
 
 features_by_pattern = {
-    '.*800.renames-and-merges/(.|apmod|emacs|ffext|gimpplugins|haskell|lib|libretro|lua|lv2|nextcloud|node|perl|php|python|rhytmbox|texlive|vim|fonts/.)\.yaml': {
+    r'.*800.renames-and-merges/(.|apmod|emacs|ffext|gimpplugins|haskell|lib|libretro|lua|lv2|nextcloud|node|perl|php|python|rhytmbox|texlive|vim|fonts/.)\.yaml': {
         'sort_field': 'setname',
     },
-    '.*850.split-ambiguities/[^cdh]\.yaml': {
+    r'.*850.split-ambiguities/[^cdh]\.yaml': {
         'sort_field': 'name',
     },
-    '.*900.version-fixes/.*\.yaml': {
+    r'.*900.version-fixes/.*\.yaml': {
         'sort_field': 'name',
         'disallowed': {'setname'},
     },


### PR DESCRIPTION
Original:
```console
$ make check
/{pwd}/repology-rules/scripts/check.py:339: SyntaxWarning: invalid escape sequence '\.'
  '.*800.renames-and-merges/(.|apmod|emacs|ffext|gimpplugins|haskell|lib|libretro|lua|lv2|nextcloud|node|perl|php|python|rhytmbox|texlive|vim|fonts/.)\.yaml': {
/{pwd}/repology-rules/scripts/check.py:342: SyntaxWarning: invalid escape sequence '\.'
  '.*850.split-ambiguities/[^cdh]\.yaml': {
/{pwd}/repology-rules/scripts/check.py:345: SyntaxWarning: invalid escape sequence '\.'
  '.*900.version-fixes/.*\.yaml': {
```

Errors resolved by setting raw str rather than str