### PR TITLE
Merge 2048-c into 2048.c

### DIFF
--- a/800.renames-and-merges/0.yaml
+++ b/800.renames-and-merges/0.yaml
@@ -9,7 +9,7 @@
 - { setname: 2048-cli,                 name: "2048", ruleset: freebsd } # differentiate from 2048-qt
 - { setname: 2048-in-terminal,         name: 2048term }
 - { setname: 2048-py,                  name: "python:2048-py" }
-- { setname: 2048.c,                   name: c2048 }
+- { setname: 2048.c,                   name: [c2048, 2048-c] }
 - { setname: 2bwm,                     name: twobwm }
 - { setname: 2ping,                    name: twoping }
 - { setname: 3270font,                 name: 3270-fonts }


### PR DESCRIPTION
Similar to Homebrew, Termux distributes `2048.c` as `2048-c`, so it should be merged.