### PR TITLE
Merge ipsw

### DIFF
--- a/800.renames-and-merges/i.yaml
+++ b/800.renames-and-merges/i.yaml
@@ -109,6 +109,7 @@
 - { setname: iproute2,                 name: iproute }
 - { setname: iproute2,                 name: iproute2-cake, addflavor: cake }
 - { setname: iproute2,                 name: iproute2-doc, addflavor: doc }
+- { setname: ipsw,                     name: ipswd, addflavor: true }
 - { setname: iptables,                 name: iptables-epel, addflavor: true } # "provides parts of iptables run-time that Red Hat doesn't want to ship"
 - { setname: iptables,                 name: [iptables-fullconenat,iptables-minimal,iptables-nosystemd-minimal], addflavor: true }
 - { setname: iptables,                 name: compat-iptables }


### PR DESCRIPTION
`ipswd` is a daemon part of the [`ipsw`](https://github.com/blacktop/ipsw) project, so it should be merged with `ipsw`