### PR TITLE
Update Sherlock Proj

### DIFF
--- a/800.renames-and-merges/s.yaml
+++ b/800.renames-and-merges/s.yaml
@@ -145,6 +145,7 @@
 - { setname: shellcheck,               name: shellcheck-bin, addflavor: true }
 - { setname: shellcheck,               name: "haskell:shellcheck" }
 - { setname: sherlock,                 name: python:sherlock-project }
+- { setname: sherlock-social-osint,    name: sherlock-project }
 - { setname: shfmt,                    name: $0-bin }
 - { setname: shibboleth-sp,            namepat: "shibboleth-sp[0-9]+" }
 - { setname: shiboken,                 name: python:shiboken }

--- a/800.renames-and-merges/s.yaml
+++ b/800.renames-and-merges/s.yaml
@@ -145,7 +145,7 @@
 - { setname: shellcheck,               name: shellcheck-bin, addflavor: true }
 - { setname: shellcheck,               name: "haskell:shellcheck" }
 - { setname: sherlock,                 name: python:sherlock-project }
-- { setname: sherlock-social-osint,    name: sherlock-project }
+- { setname: sherlock,                 name: sherlock-project }
 - { setname: shfmt,                    name: $0-bin }
 - { setname: shibboleth-sp,            namepat: "shibboleth-sp[0-9]+" }
 - { setname: shiboken,                 name: python:shiboken }

--- a/850.split-ambiguities/s.yaml
+++ b/850.split-ambiguities/s.yaml
@@ -158,7 +158,7 @@
 - { name: shed, addflag: unclassified }
 
 - { name: sherlock, wwwpart: open-music-kontrollers, setname: lv2:sherlock }
-- { name: sherlock, wwwpart: sherlock-project, setname: sherlock-social-osint }
+- { name: sherlock, wwwpat: sherlock-?project, setname: sherlock-social-osint }
 - { name: sherlock, wwwpart: sergius02, setname: sherlock-ip-info }
 - { name: sherlock, addflag: unclassified }
 

--- a/850.split-ambiguities/s.yaml
+++ b/850.split-ambiguities/s.yaml
@@ -158,7 +158,7 @@
 - { name: shed, addflag: unclassified }
 
 - { name: sherlock, wwwpart: open-music-kontrollers, setname: lv2:sherlock }
-- { name: sherlock, wwwpat: sherlock-?project, setname: sherlock-social-osint }
+- { name: sherlock, wwwpat: "sherlock-?project", setname: sherlock-social-osint }
 - { name: sherlock, wwwpart: sergius02, setname: sherlock-ip-info }
 - { name: sherlock, addflag: unclassified }
 


### PR DESCRIPTION
Sherlock now uses sherlockproject[.]xyz rather than sherlock-project[.]github[.]io in some locations. This change will merge any packages that stray by using the new domain. Currently, one seems to have separated (Homebrew).

This also merges the Fedora package, sherlock-project, with the rest of the relevant packages at sherlock-social-osint, reducing 3 apparent projects to 1.

___

__Aside:__

While opening this PR, I had wondered... is there anything actually making this project use sherlock-social-osint rather than just sherlock? There is a python:sherlock, but this isn't in any real conflict as one is a library, therefore prefaced with python:, and the other is an application, almost always without preface when presented.

https://github.com/repology/repology-rules/blob/6192111764810e93150afd5bbd6bcc9ecf9dea5f/800.renames-and-merges/s.yaml#L147

This snippet from two months ago seems to agree with reverting the name to simply `sherlock`

(figured I'd ask while PRing anyways)