### PR TITLE
Fix senpai-irc classification for new upstream location

### DIFF
--- a/850.split-ambiguities/s.yaml
+++ b/850.split-ambiguities/s.yaml
@@ -119,7 +119,7 @@
 - { name: selene, addflag: unclassified }
 
 - { name: senpai, wwwpart: chess, setname: senpai-chess }
-- { name: senpai, wwwpart: taiite, setname: senpai-irc }
+- { name: senpai, wwwpart: [taiite,delthas], setname: senpai-irc }
 - { name: senpai, addflag: unclassified }
 
 - { name: sensors, wwwpart: lm-sensors, setname: lm-sensors } # XXX: problem


### PR DESCRIPTION
~~The chess engine is no longer packaged in AUR (nor was it ever packaged
anywhere else), so this is no longer necessary. The classification was
already a bit broken due to the upstream move from
[git.sr.ht/~taiite/senpai](https://git.sr.ht/~taiite/senpai) to [git.sr.ht/~delthas/senpai](https://git.sr.ht/~delthas/senpai/),
but I think removing it entirely is a better option than fixing it.~~

The upstream repository recently moved from https://git.sr.ht/~taiite/senpai to https://git.sr.ht/~delthas/senpai.
