### PR TITLE
Merge git-gamble

### DIFF
--- a/800.renames-and-merges/g.yaml
+++ b/800.renames-and-merges/g.yaml
@@ -141,6 +141,7 @@
 - { setname: git-delete-merged-branches, name: "python:$0" }
 - { setname: git-delta,                name: "rust:git-delta" }
 - { setname: git-for-windows,          name: msysgit } # https://github.com/git-for-windows/git/wiki/FAQ#what-is-the-relationship-between-git-for-windows-and-msysgit
+- { setname: git-gamble,               name: "rust:git-gamble" }
 - { setname: git-hound,                name: githound }
 - { setname: git-review,               name: "python:git-review" }
 - { setname: git-review,               name: git-reveiw } # XXX: CREATE PROBLEM


### PR DESCRIPTION
[The git-gamble page](https://repology.org/project/git-gamble/versions) doesn't show that the crate is available on [crates.io](https://crates.io/crates/git-gamble)

I made this PR because i think it will show that the package is also available on crates.io, but maybe that is not how it should be done