### PR TITLE
Remove outdated verignore for ccls

### DIFF
--- a/900.version-fixes/c.yaml
+++ b/900.version-fixes/c.yaml
@@ -80,7 +80,6 @@
 - { name: ccid,                                                      ruleset: t2,          untrusted: true } # accused of fake 1.54
 - { name: ccls,                        ver: "0.20231116",                                  incorrect: true } # made up, not official
 - { name: ccls,                                                      ruleset: freebsd,     untrusted: true } # accused of fake 0.20190731, 0.20231116
-- { name: ccls,                        ver: "0.20240202",                                  incorrect: true } # made up, not official
 - { name: ccls,                                                      ruleset: termux,      untrusted: true } # accused of fake 0.20240202
 - { name: ccnet,                                                     ruleset: sisyphus,    untrusted: true } # ccnet-server really
 - { name: cd-discid,                   ver: "1.4.14",                ruleset: freebsd,     incorrect: true }


### PR DESCRIPTION
0.20240202 exists - https://github.com/MaskRay/ccls/releases/tag/0.20240202

I think this rule is incorrectly marking majority of repositories as on an "incorrect version" https://repology.org/project/ccls/information