### PR TITLE
Merge gnome-sushi with sushi

### DIFF
--- a/800.renames-and-merges/s.yaml
+++ b/800.renames-and-merges/s.yaml
@@ -432,6 +432,7 @@
 - { setname: surge,                    name: surge-synthesizer-lv2, addflavor: lv2 }
 - { setname: surge-xt,                 name: surgext }
 - { setname: surge-xt,                 name: surge-synthesizer-xt-lv2, addflavor: lv2 }
+- { setname: sushi,                    name: gnome-sushi }
 - { setname: svg2tikz,                 name: python:$0 }
 - { setname: svgcleaner,               name: "rust:svgcleaner" }
 - { setname: svgo,                     name: "node:svgo" }


### PR DESCRIPTION
gnome-sushi is a Debian-specific name of this app.