### PR TITLE
Fix splitting sushi

### DIFF
--- a/850.split-ambiguities/s.yaml
+++ b/850.split-ambiguities/s.yaml
@@ -560,7 +560,7 @@
 - { name: surf, sourceforge: surf, setname: surf-alggeo }
 - { name: surf, addflag: unclassified }
 
-- { name: sushi, wwwpart: gitlab.gnome.org/GNOME/sushi, setname: gnome-sushi }
+- { name: sushi, wwwpart: gnome, setname: gnome-sushi }
 - { name: sushi, addflag: unclassified }
 
 - { name: svn2git, wwwpart: [svn-all-fast-export,gitorious.org/svn2git], setname: svn-all-fast-export }


### PR DESCRIPTION
Check only for 'gnome' in the URL.