### PR TITLE
verignore for bin2iso

### DIFF
--- a/900.version-fixes/b.yaml
+++ b/900.version-fixes/b.yaml
@@ -68,6 +68,7 @@
 - { name: biew,                        verpat: "[0-9]{3}.*",                               incorrect: true }
 - { name: bilibili,                    ver: "1.13.2.3297",           ruleset: homebrew_casks, incorrect: true }
 - { name: bilibili,                                                  ruleset: homebrew_casks, untrusted: true } # accused of fake 1.13.2.3297
+- { name: bin2iso,                     ver: "19b",                                         incorrect: true } # mistyped 1.9b
 - { name: bind,                                                                            p_is_patch: true }
 - { name: bind,                        verpat: "[0-9]+\\.[0-9]*[13579]\\..*", verge: "9.13.0", devel: true } # https://lists.isc.org/pipermail/bind-announce/2018-May/001092.html
 - { name: bind,                        ver: "9.13.3",                ruleset: debuntu,     incorrect: true }


### PR DESCRIPTION
Hope this is corerct

Add verignore for bin2iso, Gentoo (unmaintained) and T2 SDE (maintainer unreachable) type 19b instead of 1.9b

Slackware corrected it recently

https://repology.org/project/bin2iso/versions
https://gitlab.com/bunnylin/bin2iso/-/blob/main/CHANGELOG?ref_type=heads