### PR TITLE
fix: merge Buildpacks `pack` CLI entries

### DIFF
--- a/800.renames-and-merges/p.yaml
+++ b/800.renames-and-merges/p.yaml
@@ -7,6 +7,7 @@
 - { setname: pacaur,                   name: pacaur-no-ud, addflavor: true }
 - { setname: pace,                     name: [pace-cli, rust:pace-rs] } # different projects, split in 850
 - { setname: pacemaker,                name: pacemaker1.1 }
+- { setname: pack,                     name: [buildpacks-cli, pack-cli] }
 - { setname: packagekit,               name: compat-packagekit08, disposable: true }
 - { setname: packagekit,               name: [packagekit-gtk,libpackagekit-glib, packagekit-base], addflavor: true }
 - { setname: packagekit-qt,            name: packagekit-qt5, addflavor: true }


### PR DESCRIPTION
Merges OpenSUSE"s package for the Buildpacks `pack` CLI with the other repos.