### PR TITLE
Split mp3cat, merge mp3cat-go

### DIFF
--- a/800.renames-and-merges/m.yaml
+++ b/800.renames-and-merges/m.yaml
@@ -299,6 +299,7 @@
 - { setname: mozo,                     name: mozo-gtk2, addflavor: true }
 - { setname: mozo,                     name: mozo-dev, weak_devel: true, nolegacy: true }
 - { setname: mozvoikko,                name: [browser-plugin-mozvoikko,firefox-ext-mozvoikko] }
+- { setname: mp3cat,                   name: mp3cat-go }
 - { setname: mpc,                      name: [mpd-mpc,mpclient,mpc-client,mpcli,musicpc,mpdc] }
 - { setname: mpc-hc,                   name: mediaplayerclassichomecinema }
 - { setname: mpd,                      name: [mpd-light,mpd-light-pulse,mpd-minimal,mpd-server-minimal,mpd-sidplay,mpd-lightest,mpd-light-pulse-ffmpeg,mpd-smbclient], addflavor: true }

--- a/850.split-ambiguities/m.yaml
+++ b/850.split-ambiguities/m.yaml
@@ -294,6 +294,10 @@
 - { name: monocle, wwwpart: packetstormsecurity, setname: monocle-host-discovery }
 - { name: monocle, addflag: unclassified }
 
+- { name: mp3cat, wwwpart: dmulholl, setname: mp3cat-dmulholl }
+- { name: mp3cat, wwwpart: tomclegg, setname: mp3cat-tomclegg }
+- { name: mp3cat, addflag: unclassified }
+
 - { name: mp3check, wwwpart: icculus, setname: mp3check-icculus }
 
 - { name: mp4ff, wwwpart: Eyevinn, setname: "go:mp4ff" }


### PR DESCRIPTION
There seems to be some ambiguity between two projects with the same name. `mp3cat` was [originally written by Tom Clegg](https://github.com/tomclegg/mp3cat), yet [there exists a different project written by someone else with the same name](https://github.com/dmulholl/mp3cat), only it has a different function and is written in Go.

For Termux, Repology already recognizes the correct name of the package (`mp3cat-go`), so this serves as a change that will split the packages in two, which should also fix issues regarding versions, which also differ (0.5 vs. 4.2.2)