### PR TITLE
The fake avahi is 0.9, not 0.8 (realy fixes #887)

### DIFF
--- a/900.version-fixes/a.yaml
+++ b/900.version-fixes/a.yaml
@@ -366,8 +366,8 @@
 - { name: autotools,                                                                       noscheme: true }
 - { name: autotrace,                   verpat: ".*20[0-9]{6}.*",                           snapshot: true } # 0.31.1 latest
 - { name: av1an,                       ver: ["5.5.4","6.1.5"],                             sink: true } # legacy python code removed from the main repo
-- { name: avahi,                       ver: "0.8",                   ruleset: arch,        incorrect: true }
-- { name: avahi,                                                     ruleset: arch,        untrusted: true } # accused of fake 0.8 (archpower)
+- { name: avahi,                       ver: "0.9",                   ruleset: arch,        incorrect: true }
+- { name: avahi,                                                     ruleset: arch,        untrusted: true } # accused of fake 0.9 (archpower)
 - { name: avidemux,                    ver: "2.7.7",                 ruleset: rpm,         incorrect: true }
 - { name: avidemux,                                                  ruleset: rpm,         untrusted: true } # accused of fake 2.7.7
 - { name: avidemux,                    ver: "2.7.8.210306",          ruleset: winget,      incorrect: true }


### PR DESCRIPTION
0.8 is the legit version, 0.9 is the fake