### PR TITLE
Merge sgrep

### DIFF
--- a/800.renames-and-merges/s.yaml
+++ b/800.renames-and-merges/s.yaml
@@ -142,6 +142,7 @@
 - { setname: sfml,                     name: compat-sfml16 }
 - { setname: sfml,                     namepat: "(?:lib)?sfml[0-9.-]*" }
 - { setname: sfml,                     name: sfml-static, addflavor: true }
+- { setname: sgrep,                    name: sgrep2 }
 - { setname: sgt-puzzles,              name: [simon-tathams-portable-puzzle-collection, tatham-puzzles] }
 - { setname: sgt-puzzles,              name: puzzles } # not completely safe, but other puzzles were not encountered yet
 - { setname: sha1collisiondetection,   name: sha1dc }


### PR DESCRIPTION
`sgrep` and `sgrep2` are the same packages. Repositories, like MacPorts, contain both to distribute the stable and latest version, but they come from the same upstream.