### PR TITLE
Extend merge for Linux

### DIFF
--- a/800.renames-and-merges/linux.yaml
+++ b/800.renames-and-merges/linux.yaml
@@ -34,6 +34,7 @@
     - kernel-userspace-headers
     - kernel-vanilla
     - linux-api-headers
+    - linux-desktop
     - linux-edge
     - linux-header
     - linux-headers


### PR DESCRIPTION
Hi, this merge SerpentOS Linux kernel which is called `linux-desktop` there https://github.com/serpent-os/recipes/blob/main/l/linux-desktop/manifest.x86_64.jsonc