### PR TITLE
Remove old rules

### DIFF
--- a/800.renames-and-merges/v.yaml
+++ b/800.renames-and-merges/v.yaml
@@ -95,8 +95,7 @@
 - { setname: vte,                      namepat: "(?:lib)?vte[0-9.-]*" }
 - { setname: vte-ng,                   name: vte3-ng }
 - { setname: vte-ng,                   name: [vte3-ng-emoji-terminix-zsh-notify, vte3-ng-fullwidth-emoji], addflavor: true }
-- { setname: vtk,                      namepat: "vtk[0-9.-]*(?:-?(base|data|doc|doc-html|docs|qt4|qvtk)[0-9.-]*)?", addflavor: $1 }
-- { setname: vtk,                      name: vtk6-legacy }
+- { setname: vtk,                      namepat: "vtk[0-9.-]*(?:-?(base|data|doc|doc-html|docs|qvtk)[0-9.-]*)?", addflavor: $1 }
 - { setname: vtk,                      name: [vtk-openmpi, vtk-openmpi2, vtk-openmpi3, vtk-openmpi4], addflavor: true }
 - { setname: vue-cli,                  name: "node:vue-cli" }
 - { setname: vulkan-extensionlayer,    name: vulkan-extension-layer }

--- a/900.version-fixes/b.yaml
+++ b/900.version-fixes/b.yaml
@@ -65,8 +65,6 @@
 - { name: beret,                                                                           noscheme: true }
 - { name: berkeley-abc,                                                                    noscheme: true }
 - { name: bettercap-caplets,                                                               noscheme: true }
-- { name: betty,                                                     ruleset: aur,         untrusted: true }
-- { name: betty,                       ver: "0.1.8",                 ruleset: aur,         incorrect: true }
 - { name: bibtex2html,                 verlonger: 2,                 ruleset: aur,         incorrect: true }
 - { name: biew,                        verpat: "[0-9]{3}.*",                               incorrect: true }
 - { name: bilibili,                    ver: "1.13.2.3297",           ruleset: homebrew_casks, incorrect: true }


### PR DESCRIPTION
Hi, this remove some old rules

* no longer exist a Qt4 variant of VTK
* `vtk6-legacy` have been removed from AUR https://lists.archlinux.org/archives/list/aur-requests@lists.archlinux.org/thread/UUUI5BHY27SE6IK2B4243NL7CRWTLPCT/#HWGSHNV7XLU4D77PU7DGN6WC7ZKPUBGR
* `betty` have been removed from AUR (requested myself) https://lists.archlinux.org/archives/list/aur-requests@lists.archlinux.org/thread/GYDKUY25ZDXOQOSUKQAICCZQQZ5KYATQ/#5DRSXLXZF7TBYBNVN2VSBJ3M765DABV4