### PR TITLE
Merge vulkan-caps-viewer

### DIFF
--- a/800.renames-and-merges/v.yaml
+++ b/800.renames-and-merges/v.yaml
@@ -99,6 +99,7 @@
 - { setname: vtk,                      name: vtk6-legacy }
 - { setname: vtk,                      name: [vtk-openmpi, vtk-openmpi2, vtk-openmpi3, vtk-openmpi4], addflavor: true }
 - { setname: vue-cli,                  name: "node:vue-cli" }
+- { setname: vulkan-caps-viewer,       name: [vulkan-caps-viewer-wayland,vulkan-caps-viewer-x11], addflavor: true }
 - { setname: vulkan-extensionlayer,    name: vulkan-extension-layer }
 - { setname: vulkan-loader,            name: vulkan-icd-loader }
 - { setname: vulkan-sdk,               name: vulkan-sdk-bin, addflavor: bin }


### PR DESCRIPTION
https://repology.org/projects/?search=vulkan-caps-viewer

Hi, this merge the `-bin` pkgbuilds of `vulkan-caps-viewer` on AUR, this isn't needed for the from source versions since that is a splitted pkgbuild with `pkgbase=vulkan-caps-viewer`