### PR TITLE
Remove outdated noscheme for apfsprogs

### DIFF
--- a/900.version-fixes/a.yaml
+++ b/900.version-fixes/a.yaml
@@ -202,7 +202,6 @@
 - { name: apache-directory-studio,     verpat: ".*20[0-9]{6}[.-][0-9]+",                   incorrect: true } # 2.0.0.v20210717-M17, not 2.0.0.v20210717.17
 - { name: apache-directory-studio,     verpat: ".*20[0-9]{6}",                             incorrect: true } # 2.0.0.v20210717-M17, not 2.0.0.v20210717
 - { name: apel,                        verpat: ".*20[0-9]{6}",                             snapshot: true }
-- { name: apfsprogs,                                                                       noscheme: true } # no tags, binaries and man pages show 0.1 as a "version"
 - { name: apidb,                       ver: "5.0.0",                 ruleset: aur,         incorrect: true }
 - { name: apidb,                                                     ruleset: aur,         untrusted: true } # accused of fake 5.0.0
 - { name: apiextractor,                ver: "0.10.11",               ruleset: sisyphus,    incorrect: true }


### PR DESCRIPTION
Reverts https://github.com/repology/repology-rules/pull/496.
apfsprogs recently got its first release: https://github.com/linux-apfs/apfsprogs/releases/tag/v0.2.0.
Also see https://repology.org/project/apfsprogs/versions.
Maybe we need some rules to sink or ignore older versions which compare greater than 0.2. But without trying it out locally, I'm having a hard time figuring out which versions exactly need ignoring, so I'm counting on your experience.