### PR TITLE
Rename wallpapers to ataraxia-wallpapers

### DIFF
--- a/850.split-ambiguities/w.yaml
+++ b/850.split-ambiguities/w.yaml
@@ -9,6 +9,10 @@
 - { name: wakeonlan, wwwpart: remcohaszing, setname: "python:wakeonlan" }
 - { name: wakeonlan, addflag: unclassified }
 
+# Technically not a disambiguation since there's only one package with this name,
+# but it's generic and should be renamed to avoid potential future conflicts 
+- { name: wallpapers, wwwpart: ataraxialinux, setname: ataraxia-wallpapers }
+
 - { name: warp, wwwpart: facebook, setname: warp-preprocessor }
 - { name: warp, wwwpart: one.one.one.one, setname: warp-vpn }
 - { name: warp, wwwpart: gnome.org, setname: warp-share-files }


### PR DESCRIPTION
Technically not a disambiguation since there's only one package with this name, but it's generic and should be renamed to avoid potential future conflicts. If this would be more appropriate for `800.renames-and-merges`, let me know and I'll move it there.