### PR TITLE
Merge minecraft into minecraft-launcher

### DIFF
--- a/800.renames-and-merges/m.yaml
+++ b/800.renames-and-merges/m.yaml
@@ -221,6 +221,7 @@
 - { setname: mina,                     name: [apache-mina,apache-mina1,mina2] }
 - { setname: mina,                     name: mina-core, addflavor: true }
 - { setname: minder,                   name: minder-app }
+- { setname: minecraft-launcher,       name: minecraft }
 - { setname: minecraft-technic-launcher, name: technic-launcher }
 - { setname: minetest-mineclone2,      name: [minetest-mineclone, mineclone-2] }
 - { setname: minetest-mineclone5,      name: mineclone-5 }

--- a/900.version-fixes/m.yaml
+++ b/900.version-fixes/m.yaml
@@ -127,7 +127,8 @@
 - { name: mimetex,                     verpat: "20[0-9]{6}.*",                             incorrect: true }
 - { name: mimikatz,                    verpat: ".*20[0-9]{6}",                             ignore: true } # BlackArch snap
 - { name: minbif,                      verpat: ".*20[0-9]{6}",                             ignore: true }
-- { name: minecraft-launcher,          verpat: ".*[0-9]{3,}.*",                            incorrect: true } # 2.2.xxxx is old launcher version that is obsolete, and bare xxx is old bootstrap version that needs to be masked for algorithm to work
+- { name: minecraft-launcher,          verpat: ".*[0-9]{3,}.*",                            sink: true } # 2.2.xxxx is old launcher version that is obsolete, and bare xxx is old bootstrap version that needs to be masked for algorithm to work
+- { name: minecraft-launcher,          verpat: "20[0-9]{6}",                               ignore: true } # unrelated timestamp
 - { name: minetest-mineclone5,         verpat: "5(\\.[0-9]+){2}",                          incorrect: true } # 5 is part of the name, not version
 - { name: ming,                        verpat: ".*20[0-9]{6}",                             snapshot: true }
 - { name: ming,                        ver: "0.4.9",                 ruleset: rpm,         incorrect: true }

--- a/900.version-fixes/m.yaml
+++ b/900.version-fixes/m.yaml
@@ -127,6 +127,7 @@
 - { name: mimetex,                     verpat: "20[0-9]{6}.*",                             incorrect: true }
 - { name: mimikatz,                    verpat: ".*20[0-9]{6}",                             ignore: true } # BlackArch snap
 - { name: minbif,                      verpat: ".*20[0-9]{6}",                             ignore: true }
+- { name: minecraft-launcher,          verpat: ".*[0-9]{3,}.*",                            incorrect: true } # 2.2.xxxx is old launcher version that is obsolete, and bare xxx is old bootstrap version that needs to be masked for algorithm to work
 - { name: minetest-mineclone5,         verpat: "5(\\.[0-9]+){2}",                          incorrect: true } # 5 is part of the name, not version
 - { name: ming,                        verpat: ".*20[0-9]{6}",                             snapshot: true }
 - { name: ming,                        ver: "0.4.9",                 ruleset: rpm,         incorrect: true }

--- a/900.version-fixes/m.yaml
+++ b/900.version-fixes/m.yaml
@@ -127,8 +127,10 @@
 - { name: mimetex,                     verpat: "20[0-9]{6}.*",                             incorrect: true }
 - { name: mimikatz,                    verpat: ".*20[0-9]{6}",                             ignore: true } # BlackArch snap
 - { name: minbif,                      verpat: ".*20[0-9]{6}",                             ignore: true }
-- { name: minecraft-launcher,          verpat: ".*[0-9]{3,}.*",                            sink: true } # 2.2.xxxx is old launcher version that is obsolete, and bare xxx is old bootstrap version that needs to be masked for algorithm to work
-- { name: minecraft-launcher,          verpat: "20[0-9]{6}",                               ignore: true } # unrelated timestamp
+- { name: minecraft-launcher,          verpat: "2\\.2\\.[0-9]{3,4}",                       sink: true } # 2.2.xxx[x] is old launcher version that is obsolete
+- { name: minecraft-launcher,          verpat: "[0-9]{3,4}",                               sink: true } # bare xxx is old bootstrap version that needs to be sinked for the algorithm to work
+- { name: minecraft-launcher,          verpat: "20[0-9]{6}",                               incorrect: true } # prevent possible future timestamps
+- { name: minecraft-launcher,          verpat: "20130712",                                 sink: true } # unrelated timestamp
 - { name: minetest-mineclone5,         verpat: "5(\\.[0-9]+){2}",                          incorrect: true } # 5 is part of the name, not version
 - { name: ming,                        verpat: ".*20[0-9]{6}",                             snapshot: true }
 - { name: ming,                        ver: "0.4.9",                 ruleset: rpm,         incorrect: true }


### PR DESCRIPTION
This PR consists of two parts; the first is to merge [minecraft](https://repology.org/project/minecraft/versions) into [minecraft-launcher](https://repology.org/project/minecraft-launcher/versions). These two projects all refer to the same official Minecraft Launcher, and it seems that the latter is the name used by more projects. Hopefully, this part is uncontroversial.

The other part is to ignore all versions that look like `2.2.xxxx` and bare `xxxx`. The reasoning for this is the huge mess that is the versioning scheme of the Minecraft Launcher itself... Some background:
- There are two version numbers attached to the Minecraft Launcher: the launcher version itself (shown on the lower left of the launcher's main screen) and the launcher bootstrap version (obtainable from the About menu, Info.plist on macOS for the launcher app). When downloading the launcher from minecraft.net, only the bootstrap is downloaded, which will in turn download and update the real launcher when executed. (Note: All version figures below refer to the Linux version of the launcher; the version deviates slightly between different OSes)
- These two versions are completely unrelated. For example, as of the creation of this PR, the latest bootstrap version is `2.1.3(1)`, and the latest launcher version is `3.6.2`.
- However, the bootstrap had not always been here. Before March 2021, bootstrap is on Windows and macOS, but not on Linux. Instead, the then-current download URL `https://launcher.mojang.com/download/linux/x86_64/minecraft-launcher_2.2.xxxx.tar.gz` (back then the launcher version was `2.2.xxxx`) directly gives you the launcher itself, and thus most repos just used the launcher version.
- On March 1st, 2021, Minecraft Launcher version `2.2.2159` for Linux [was released](https://minecraft.wiki/w/Launcher_2.2.21xx), giving Linux the bootstrap functionality to implement auto-update. With this change, the above URL became `https://launcher.mojang.com/download/linux/x86_64/minecraft-launcher_887.tar.gz`, where `887` was the bootstrap version at the time. To keep the URL in their build files working, most repos (such as Terra) started to use the bootstrap version as the version for the `minecraft-launcher` package instead, deviating from the real version of the launcher.
- On March 7th, 2022, with the release of Minecraft Launcher version `2.2.11106` and bootstrap version `1121`, the above URL is updated for the last time. Since then, version `1121` has been the last available bootstrap version from the above URL format. (The actual launcher version is irrelevant anyway since the bootstrap will download the latest one) [EDIT: apparently in June 2022 another update had made bootstrap version `1.0.1221` available from this URL format, which is the true last available version as 2.1.3 is not available to this day.]
- Since then, somewhere between June 2022 and October 2024, the bootstrap version was updated to `2.1.3(1)`. In light of this, several repos (like AUR) [transformed](https://aur.archlinux.org/cgit/aur.git/commit/?h=minecraft-launcher&id=3ed1d182751aa2b3bb60a9a6baa5c0a420eec711) to use the official URL accessible from [minecraft.net](https://www.minecraft.net/en-us/download), which can get the latest bootstrap but lacks versioning information in the URL. Nevertheless, the bootstrap version is readily available from other channels such as Info.plist.

So TLDR there are four forms of version on `minecraft[-launcher]` package that exists today:
1. `20130712` (CRUX 3.4): this is just a timestamp of a legacy download URL.
2. `1.16.2` (choco, deprecated package) and `1.19.2` (SlackBuilds): this is back when the launcher still uses the game version as the versioning scheme.
3. `2.2.xxx[x]` (Chromebrew, CRUX 3.5, nixpkgs) and `1.0.x` (choco, Gentoo, MPR, openSUSE): this is the *launcher* version back when it can still be tracked by URL before March 2021. All the mentioned packages had thus not been updated for at least 4 years at this point.
4. `xxx` (bare three/four digits) (CRUX 3.6, Terra): this is the bootstrap versioning scheme as of March 2022, and for `2.1.3` (and later) to be recognized as the latest version, these must be marked ignored/incorrect too.
5. `2.1.3` (AUR, Homebrew Cask): this is the current bootstrap versioning scheme.

Therefore, the second part of the PR is just trying to mark all the first four categories as incorrect. Theoretically, marking each separately should be more appropriate, but as the launcher version had transitioned away from three/four-digit version numbers since 2023, I believe that future bootstrap versions will also just be 1-2 digits for each part at most, so I just banned all version strings with three or more consecutive digits for now.