### PR TITLE
update obsolete rule for dovecot-pigeonhole

### DIFF
--- a/900.version-fixes/d.yaml
+++ b/900.version-fixes/d.yaml
@@ -171,7 +171,8 @@
 - { name: double-conversion,                                         ruleset: freebsd,     untrusted: true } # accused of fake 3.1.5.19
 - { name: doublecmd,                                                                       devel: false } # they state all version to be beta: https://sourceforge.net/p/doublecmd/news/, this is pointless
 - { name: doublecmd,                   verpat: ".*svn.*",                                  ignore: true }
-- { name: dovecot-pigeonhole,          verpat: "2\\..*",                                   incorrect: true } # dovecot version prepended (openwrt, pld)
+- { name: dovecot-pigeonhole,          verpat: "2\.[0-9].*[-_].*",                         incorrect: true } # dovecot version prepended with separator (openwrt, pld)
+- { name: dovecot-pigeonhole,          verpat: "2\.[0-9]\.[0-9][0-9]?\.[0-9]\.[0-9].*",    incorrect: true } # dovecot version prepended with dot (openmamba)
 - { name: dpdk,                        verpat: ".*-.*",              ruleset: nix,         incorrect: true } # kernel version appended
 - { name: dpic,                        verpat: "20[0-9]{6}",                               incorrect: true } # 2019.08.30
 - { name: dpic,                        verge: "20000000", verlt: "20190830",               sink: true }

--- a/900.version-fixes/d.yaml
+++ b/900.version-fixes/d.yaml
@@ -171,8 +171,8 @@
 - { name: double-conversion,                                         ruleset: freebsd,     untrusted: true } # accused of fake 3.1.5.19
 - { name: doublecmd,                                                                       devel: false } # they state all version to be beta: https://sourceforge.net/p/doublecmd/news/, this is pointless
 - { name: doublecmd,                   verpat: ".*svn.*",                                  ignore: true }
-- { name: dovecot-pigeonhole,          verpat: "2\.[0-9].*[-_].*",                         incorrect: true } # dovecot version prepended with separator (openwrt, pld)
-- { name: dovecot-pigeonhole,          verpat: "2\.[0-9]\.[0-9][0-9]?\.[0-9]\.[0-9].*",    incorrect: true } # dovecot version prepended with dot (openmamba)
+- { name: dovecot-pigeonhole,          verpat: "2\\.[0-9].*[-_].*",                        incorrect: true } # dovecot version prepended with separator (openwrt, pld)
+- { name: dovecot-pigeonhole,          verpat: "2\\.[0-9]\\.[0-9][0-9]?\\.[0-9]\\.[0-9].*", incorrect: true } # dovecot version prepended with dot (openmamba)
 - { name: dpdk,                        verpat: ".*-.*",              ruleset: nix,         incorrect: true } # kernel version appended
 - { name: dpic,                        verpat: "20[0-9]{6}",                               incorrect: true } # 2019.08.30
 - { name: dpic,                        verge: "20000000", verlt: "20190830",               sink: true }


### PR DESCRIPTION
The version scheme changed to match dovecot.
The previous version was 0.5.21.1 and the current version is 2.4.0. Some repos prepended the pigeonhole version with the dovecot version, e.g. 2.3_0.5.21.1, but the rule to mark these incorrect also marks 2.4.0 incorrect.

Update the rule to mark any version with hyphen or underscore incorrect. Add a second rule to mark any version with more than 4 number groups incorrect (all single digits except third group which has optional second digit).

These should continue to mark prepended version incorrect while letting true dovecot-pigeonhole versions through.