### PR TITLE
Merge vim-just

### DIFF
--- a/800.renames-and-merges/vim:.yaml
+++ b/800.renames-and-merges/vim:.yaml
@@ -18,6 +18,7 @@
 - { setname: vim:telescope.nvim,       name: neovim-telescope }
 - { setname: vim:vim-clap,             name: [vim-clap] }
 - { setname: vim:vim-flake8,           name: [vim-plugin-flake8,vim-flake8] }
+- { setname: vim:vim-just,             name: [vim-just] }
 - { setname: vim:vim-latex,            name: [vim-latex,vim-latexsuite] }
 - { setname: vim:vim-sayonara,         name: vim-sayonara }
 - { setname: vim:wayland-clipboard,    name: [vim-wayland-clipboard, vim:vim-wayland-clipboard] }


### PR DESCRIPTION
Currently Repology splits the list of `vim-just` packages into two separate projects: [[1]](https://repology.org/project/vim:vim-just/versions), [[2]](https://repology.org/project/vim-just/versions).

This PR aims to unify these so that all `vim-just` packages are listed under https://repology.org/project/vim:vim-just/versions .