### PR TITLE
Add apt-swarm rules

### DIFF
--- a/800.renames-and-merges/a.yaml
+++ b/800.renames-and-merges/a.yaml
@@ -260,6 +260,7 @@
 - { setname: apr-util,                 name: [aprutil1,apr-util0,apr0-util] }
 - { setname: apr-util,                 namepat: "(?:lib)?apr-?util[0-9.-]*" }
 - { setname: apt-dater,                name: $0-legacy }
+- { setname: apt-swarm,                name: rust:$0 }
 - { setname: aptana-studio,            name: aptanastudio }
 - { setname: aqbanking,                namepat: "(?:lib)?aqbanking[0-9]*(-(?:gtk)[0-9]*)?", addflavor: $1 }
 - { setname: aqbanking,                namepat: "(?:lib)?aqbanking[0-9]*(-(?:gtk)[0-9]*)?(?:-svn|-devel)", addflavor: $1, weak_devel: true, nolegacy: true }


### PR DESCRIPTION
This is so the [Debian package](https://packages.debian.org/sid/apt-swarm) and the [Arch Linux package](https://archlinux.org/packages/extra/x86_64/apt-swarm/) are listed together (although the later hasn't been processed by repology.org yet).

Thanks!