### PR TITLE
acpitool 0.5.2 exists

### DIFF
--- a/900.version-fixes/a.yaml
+++ b/900.version-fixes/a.yaml
@@ -43,8 +43,6 @@
 - { name: acpi-call,                   verlonger: 4,                                       incorrect: true } # nix X.Y.Z-U.V.W (kerner versions appended)
 - { name: acpica,                      ver: "20221022",                                    incorrect: true }
 - { name: acpica,                                                    ruleset: [homebrew,macports,pisi], untrusted: true } # accused of fake 20221022
-- { name: acpitool,                    ver: "0.5.2",                 ruleset: [t2,openmandriva], incorrect: true }
-- { name: acpitool,                                                  ruleset: [t2,openmandriva], untrusted: true } # accused of fake 0.5.2
 - { name: actiona,                     verlonger: 3,                 ruleset: freebsd,     incorrect: true }
 - { name: activitywatch,               verpat: ".*b.*",                                    devel: true }
 - { name: ada-language-server,         verpat: ".*w",                                      devel: true }


### PR DESCRIPTION
Repology currently accuses T2 and OpenMandriva of putting out a fake acpitool 0.5.2 - but acpitool 0.5.2 is not a fake and was released 6 years ago at https://pagure.io/acpitool