### PR TITLE
Merge libcpr into cpr

### DIFF
--- a/800.renames-and-merges/c.yaml
+++ b/800.renames-and-merges/c.yaml
@@ -329,6 +329,7 @@
 - { setname: cpptest,                  name: libcpptest }
 - { setname: cppunit,                  name: libcppunit }
 - { setname: cppzmq,                   name: [cppzmq-devel, libzeromq-cpp-devel], weak_devel: true, nolegacy: true } # not entirely sure whether -devel means unstable package or package for development
+- { setname: cpr,                      name: libcpr }
 - { setname: cq-editor,                name: python:$0 }
 - { setname: cqrlog,                   name: [cqrlog-gtk2,cqrlog-qt4,cqrlog-source], addflavor: true }
 - { setname: cracklib,                 name: cracklib2 }


### PR DESCRIPTION
Hi, they are the same

* https://repology.org/project/cpr/versions
* https://repology.org/project/libcpr/versions
