### PR TITLE
Merge gnome-latex into enter-tex

### DIFF
--- a/800.renames-and-merges/e.yaml
+++ b/800.renames-and-merges/e.yaml
@@ -116,6 +116,8 @@
 - { setname: enlightenment,            name: [e17] }
 - { setname: enscript,                 name: [enscript-a4,enscript-letter,enscript-letterdj], addflavor: true }
 - { setname: entagged,                 name: entagged-tageditor, ruleset: gentoo }
+- { setname: enter-tex,                name: gnome-latex } # renamed
+- { setname: enter-tex,                name: latexila } # renamed
 - { setname: environment-modules,      name: [modules,env-modules,env-modules-tcl] }
 - { setname: envision,                 name: envision-xr }
 - { setname: envoy-proxy,              name: envoyproxy }

--- a/800.renames-and-merges/g.yaml
+++ b/800.renames-and-merges/g.yaml
@@ -275,7 +275,6 @@
 - { setname: gnome-games,              name: gnome-games-full, addflavor: true }
 - { setname: gnome-keyring,            name: gnome-keyring3 }
 - { setname: gnome-klotski,            name: klotski }
-- { setname: gnome-latex,              name: latexila } # renamed
 - { setname: gnome-mahjongg,           name: gnome-games-mahjongg }
 - { setname: gnome-menus,              name: [libgnome-menus, gnome-menus2] }
 - { setname: gnome-menus,              name: gnome-menus2-dev, weak_devel: true, nolegacy: true }


### PR DESCRIPTION
The maintainer of gnome-latex (formerly latexila) has renamed the project to [enter-tex](https://gitlab.gnome.org/swilmet/enter-tex)