### PR TITLE
Split cot (cot-common-ovf-tool/rust:cot-cli)

### DIFF
--- a/850.split-ambiguities/c.yaml
+++ b/850.split-ambiguities/c.yaml
@@ -267,6 +267,10 @@
 - { name: cos, wwwpart: solarus, setname: cos-game }
 - { name: cos, addflag: unclassified }
 
+- { name: cot, wwwpart: glennmatthews, setname: cot-common-ovf-tool }
+- { name: cot, wwwpart: cot-rs, setname: "rust:cot-cli" }
+- { name: cot, addflag: unclassified }
+
 - { name: cr, wwwpart: cfungos, setname: cr.h }
 - { name: cr, wwwpart: chart-releaser, setname: chart-releaser }
 - { name: cr, wwwpart: crengine, setname: coolreader }


### PR DESCRIPTION
There seems to be two distinct packages called cot:

- https://github.com/glennmatthews/cot – Common OVF Tool, seems to be unmaintained for past 6 years
- https://github.com/cot-rs/cot – modern Rust web framework and an accompanying CLI tool (disclaimer: I am a maintainer of this)

I renamed the former to become cot-common-ovf-tool because it's been unmaintained for a long time. If this is undesirable (it was the first to "claim" the name, after all), I can rename the latter to something like `cot-rust` instead.