### PR TITLE
cot: match cot.rs in wwwpart

### DIFF
--- a/850.split-ambiguities/c.yaml
+++ b/850.split-ambiguities/c.yaml
@@ -268,7 +268,7 @@
 - { name: cos, addflag: unclassified }
 
 - { name: cot, wwwpart: glennmatthews, setname: cot-common-ovf-tool }
-- { name: cot, wwwpart: cot-rs, setname: "rust:cot-cli" }
+- { name: cot, wwwpart: [cot-rs,cot.rs], setname: "rust:cot-cli" }
 - { name: cot, addflag: unclassified }
 
 - { name: cr, wwwpart: cfungos, setname: cr.h }


### PR DESCRIPTION
Followup to #934. I initially missed that the upstream URL can be the official `cot.rs` instead of `github.com/cot-rs/cot` - this PR fixes that.