### PR TITLE
extend msquic

### DIFF
--- a/800.renames-and-merges/m.yaml
+++ b/800.renames-and-merges/m.yaml
@@ -338,6 +338,7 @@
 - { setname: msgpack-c,                name: [libmsgpack-c, msgpack-c-c, msgpack-c] }
 - { setname: msgpack-cxx,              name: [lib$0, msgpack-cpp, msgpack-c-cpp] }
 - { setname: msilbc,                   name: [libmediastreamer-ilbc, mediastreamer-plugin-msilbc] }
+- { setname: msquic,                   name: libmsquic }
 - { setname: mstflint,                 name: mstflint4 }
 - { setname: msynctool,                namepat: "msynctool[0-9]+" }
 - { setname: mt32emu,                  name: [libmt32emu, munt-mt32emu] }


### PR DESCRIPTION
Hi, this merge `libmsquic` into `msquic` 

https://repology.org/projects/?search=msquic

https://github.com/microsoft/msquic

The upstream repository and the official logo present it as msquic