### PR TITLE
Add wildcard merge for python modules in Solus

### DIFF
--- a/500.wildcard.yaml
+++ b/500.wildcard.yaml
@@ -216,6 +216,7 @@
 - { setname: "python:$2", addflag: wconce, noflag: [wconce,not_wildcard,not_python], namepat: "(python3x)-(.*)", ruleset: centos, addflavor: $1 }
 - { setname: "python:$1", addflag: wconce, noflag: [wconce,not_wildcard,not_python], namepat: "py-(.*)", ruleset: spack }
 - { setname: "python:$0", addflag: wconce, noflag: [wconce,not_wildcard,not_python], category: Development/Python, ruleset: openindiana }
+- { setname: "python:$0", addflag: wconce, noflag: [wconce,not_wildcard,not_python], category: programming.python, ruleset: solus }
 - { setname: "python:$2", addflag: wconce, noflag: [wconce,not_wildcard,not_python], namepat: "(pypy3?)-(.*)", ruleset: aur, addflavor: $1 }
 - { setname: "python:$2", addflag: wconce, noflag: [wconce,not_wildcard,not_python], namepat: "python(3[0-9][0-9])-(.*)", ruleset: opensuse, addflavor: $1 } # since 15.6
 - { setname: "python:$2", addflag: wconce, noflag: [wconce,not_wildcard,not_python], namepat: "py([23])_(.*)", ruleset: chromebrew, addflavor: $1 }


### PR DESCRIPTION
https://github.com/getsolus/packages/blob/09ca74a5a1e8f2c1581a9ea93c418f8e51cc46d3/repo_data/components.xml.in#L471-L476

The category "programming.python" is defined as being for python modules. They aren't guaranteed to have a python-* prefix, e.g.

mccabe
ptyprocess
pytest-subtests
dnspython
ruamel-yaml
ruamel-yaml-clib