### PR TITLE
Revert "Add nosceme for feedbackd"

### DIFF
--- a/900.version-fixes/f.yaml
+++ b/900.version-fixes/f.yaml
@@ -47,7 +47,6 @@
 - { name: fdupes,                      verpat: "[0-9]+",                                   ignore: true }
 - { name: fdutils,                     verpat: ".*20[0-9]{6}",                             snapshot: true }
 - { name: feathernotes,                verpat: "[0-9]{6}",                                 incorrect: true } # slitaz
-- { name: feedbackd,                                                                       noscheme: true } # there are official tags, but in braindead format v0.0.0+git20201114
 - { name: fern-wifi-cracker,           ver: "222",                                         sink: true } # that's an SVN rev, and GH repo as more commits
 - { name: fern-wifi-cracker,           verpat: "[0-9]{3}",                                 incorrect: true } # blackarch's 222
 - { namepat: "fest(lex|vox)-.*",       ver: "20040804",                                    sink: true } # some old crap from openbsd


### PR DESCRIPTION
This reverts commit 5e4f0109428baabb38cdeb7f57fffb0c9a727264.

feedbackd now properly uses semantic versioning.

See https://repology.org/project/feedbackd/versions.