### PR TITLE
rem: fix split

### DIFF
--- a/800.renames-and-merges/lib.yaml
+++ b/800.renames-and-merges/lib.yaml
@@ -281,7 +281,6 @@
 - { setname: librealsense,             namepat: "librealsense[0-9.-]+" }
 - { setname: librealsense,             name: [librealsense-legacy, realsense-sdk2, realsense2] }
 - { setname: libreddit,                name: "rust:libreddit" }
-- { setname: librem,                   name: rem }
 - { setname: librest,                  namepat: "librest[0-9.-]+" }
 - { setname: librevenge,               namepat: "librevenge[0-9.-]+" }
 - { setname: librfm,                   name: librfm5 }

--- a/850.split-ambiguities/r.yaml
+++ b/850.split-ambiguities/r.yaml
@@ -107,6 +107,8 @@
 - { name: relic, addflag: unclassified }
 
 - { name: rem, wwwpart: kykim, setname: rem-kykim }
+- { name: rem, wwwpart: [baresip,creytiv], setname: librem }
+- { name: rem, addflag: unclassified }
 
 - { name: renderer, wwwpart: grafana, setname: grafana-image-renderer } # XXX: nix problem
 - { name: renderer, addflag: unclassified }


### PR DESCRIPTION
Not too sure but I think the split from https://github.com/repology/repology-rules/commit/642b111ab16e1cbb4ccb42b591795a9ea0af2548 may have been impacted by rename added in https://github.com/repology/repology-rules/commit/bba5a504e2a14f57e309abbe0eff1cb53386b94c, e.g. https://repology.org/project/rem-kykim/information redirects to librem

Perhaps an alternative could be renaming the split rule to 
```yaml
- { name: librem, wwwpart: kykim, setname: rem-kykim }
```