### PR TITLE
brogue: split brogue-ce

### DIFF
--- a/850.split-ambiguities/b.yaml
+++ b/850.split-ambiguities/b.yaml
@@ -285,6 +285,8 @@
 - { name: brightness, wwwpart: Devorlon, setname: $0-ddcutil }
 - { name: brightness, addflag: unclassified }
 
+- { name: brogue, verge: "1.8", setname: brogue-ce }
+
 - { name: broom, wwwpart: a-camarillo, setname: broom-git-branch-cli }
 - { name: broom, wwwpart: nicoulaj, setname: broom-disk-cleaner }
 - { name: broom, addflag: unclassified }


### PR DESCRIPTION
The original brogue does document the CE version as newer versions at https://sites.google.com/site/broguegame/home
> For the most current version of Brogue, please look to Brogue: Community Edition

So it doesn't seem any original brogue will ever get a 1.8 and all 1.8+ is part of `brogue-ce` (starting from https://github.com/tmewett/BrogueCE/releases/tag/v1.8)

Wasn't sure if this needed fallback as other usage of `var{gt,ge,lt,le}` in 850 didn't.