### PR TITLE
sapling-scm: unignore git hash appendage

### DIFF
--- a/900.version-fixes/s.yaml
+++ b/900.version-fixes/s.yaml
@@ -21,6 +21,7 @@
 - { name: sane-frontends,              verge: "1.0.25",                                    incorrect: true } # https://gitlab.com/sane-project/frontends/tags latest is 1.0.14
 - { name: sane-frontends,              ver: "1.0.15",                ruleset: pclinuxos,   incorrect: true } # https://gitlab.com/sane-project/frontends/tags latest is 1.0.14
 - { name: sane-frontends,                                            ruleset: pclinuxos,   untrusted: true } # accused ofa fake 1.0.15
+- { name: sapling-scm,                 verpat: ".*[._+-][0-9]{6}[._+-][a-f0-9]{8}",        ignore: false } # official versioning scheme
 - { name: sauerbraten,                 verpat: "(?:0\\.)*(20[0-9]{2})[^0-9]?([0-9]{2})[^0-9]?([0-9]{2})(.*)", setver: "$1_$2_$3$4" } # fix version
 - { name: sauerbraten,                 verpat: "(20[0-9]{2}_[0-9]{2}_[0-9]{2})[a-z_-]+",   setver: "$1" } # remove release name (like _collect_edition)
 - { name: sauerbraten,                 ver: "2014_03_02",            ruleset: debuntu,     ignore: true } # debian fake


### PR DESCRIPTION
Trying to unignore
https://github.com/repology/repology-rules/blob/0bc7e785f817149908cb4f1887dfa099434957a6/899.version-fixes.global.yaml#L24-L26

So newer version is picked from repositories that don't support `+` and use `.` or `-` which get caught by 899 global rule.

https://sapling-scm.com/docs/introduction/installation
> The [latest release](https://github.com/facebook/sapling/releases/latest) is `0.2.20241203-120811+a2174689`.