### PR TITLE
msieve: mark svn revisions as incorrect

### DIFF
--- a/900.version-fixes/m.yaml
+++ b/900.version-fixes/m.yaml
@@ -259,6 +259,7 @@
 - { name: msgpack,                                                                         noscheme: true } # no way to tell whether it's c or cpp counterpart
 - { name: msgpuck,                     ver: "2.0.10",                ruleset: fedora,      incorrect: true }
 - { name: msgpuck,                                                   ruleset: fedora,      untrusted: true }
+- { name: msieve,                      verpat: "[0-9]{4,}",                                incorrect: true } # macports and nix
 - { name: msp430-gdb,                  verpat: ".*20[0-9]{6}",                             snapshot: true }
 - { name: mspdebug,                    verpat: ".*20[0-9]{6}",                             ignore: true }
 - { name: msv,                         verpat: "20[0-9]{6}",                               incorrect: true }


### PR DESCRIPTION
Trying to ignore the svn revisions by macports' "-devel" package and nix. Could just be `[0-9]+` though not sure if there is any risk of upstream doing version "2" release so scoped to 1000+.

Official tags are up to 1.53: https://sourceforge.net/p/msieve/code/HEAD/tree/tags/

With current development for 1.54: https://sourceforge.net/p/msieve/code/HEAD/tree/trunk/Changes