### PR TITLE
bomber: update split

### DIFF
--- a/800.renames-and-merges/b.yaml
+++ b/800.renames-and-merges/b.yaml
@@ -171,6 +171,7 @@
 - { setname: boilr,                    name: steam-boilr-gui }
 - { setname: boinc,                    name: [boinc-client,boinc-nox,boinc-server], addflavor: true }
 - { setname: bolt,                     name: puppet-bolt }
+- { setname: bomber,                   name: bomber-go }
 - { setname: bombono-dvd,              name: bombono }
 - { setname: bonnie++,                 name: bonniexx }
 - { setname: boomaga,                  name: boomaga-qt5, addflavor: true }


### PR DESCRIPTION
Following are merged:
* https://repology.org/project/bomber-go/versions 
* https://repology.org/project/bomber-sbom-security-scanner/versions

Everything unclassified in https://repology.org/project/bomber-unclassified/information looks like `kde-bomber` 