### PR TITLE
xorriso: 1.5.7 is devel

### DIFF
--- a/900.version-fixes/x.yaml
+++ b/900.version-fixes/x.yaml
@@ -149,7 +149,7 @@
 - { name: xorg-server,                 verlonger: 3,                 ruleset: crux,        ignore: true } # bogus suffux
 - { name: xorg-server,                 verpat: "[0-9]+\\.[0-9]+\\.99.*",                   devel: true }
 - { name: xorgproto,                   verpat: "20[0-9]{6}",                               incorrect: true } # 2019.2, not YYYYMMDD
-- { name: xorriso,                     ver: "1.5.1",                                       devel: true } # https://www.gnu.org/software/xorriso/ / Development snapshot
+- { name: xorriso,                     ver: "1.5.7",                                       devel: true, maintenance: true } # https://www.gnu.org/software/xorriso/ / Development snapshot
 - { name: xournal,                     ver: "4.7",                                         sink: true }
 - { name: xpdf,                        ver: "4.02",                  ruleset: freebsd,     incorrect: true }
 - { name: xpdf,                        verpat: ".*pl0",                                    incorrect: true }


### PR DESCRIPTION
Needs manual maintenance. Current development snapshot is 1.5.7 - https://www.gnu.org/software/xorriso/#download