### PR TITLE
todoist: split

### DIFF
--- a/800.renames-and-merges/t.yaml
+++ b/800.renames-and-merges/t.yaml
@@ -196,6 +196,7 @@
 - { setname: today,                    name: today-journal }
 - { setname: todo,                     name: todo.cpp }
 - { setname: todo.txt-cli,             name: [todo-txt,todotxt,todotxt-cli] }
+- { setname: todoist,                  name: [todoist-cli,todoist-electron] }
 - { setname: togl,                     name: [tcl-togl,tk-togl,togl-2.0] }
 - { setname: toilet,                   name: toilet-template }
 - { setname: tokei,                    name: "rust:tokei" }

--- a/850.split-ambiguities/t.yaml
+++ b/850.split-ambiguities/t.yaml
@@ -213,6 +213,10 @@
 - { name: todo, wwwpart: sioodmy, setname: todo-sioodmy }
 - { name: todo, addflag: unclassified }
 
+- { name: todoist, wwwpart: sachaos, setname: todoist-cli }
+- { name: todoist, wwwpart: todoist.com, addflag: classified }
+- { name: todoist, addflag: unclassified }
+
 - { name: tofu, wwwpart: [oomadness,pyserial], setname: tofu-engine }
 - { name: tofu, wwwpart: opentofu, setname: opentofu }
 - { name: tofu, addflag: unclassified }


### PR DESCRIPTION
Splitting https://repology.org/project/todoist/information 

Kept the original name for official app while renaming CLI.