### PR TITLE
wireguard-go: incorrect 0.0.20231211

### DIFF
--- a/900.version-fixes/w.yaml
+++ b/900.version-fixes/w.yaml
@@ -75,6 +75,8 @@
 - { name: wiredtiger,                                                ruleset: blackarch,   untrusted: true } # accused of fake 4.0.14 (mongodb version used by WT not really related to wiredtiger version)
 - { name: wireguard,                   verpat: "20[0-9]{6}",                               incorrect: true } # it's 0.0.20YYMMDD
 - { name: wireguard,                   verge: "1",                                         incorrect: true } # it's 0.0.20YYMMDD, not 5.4.6 and not 1.0.20191226
+- { name: wireguard-go,                ver: "0.0.20231211",          ruleset: debuntu,     incorrect: true }
+- { name: wireguard-go,                                              ruleset: debuntu,     untrusted: true } # accused of fake 0.0.20231211
 - { name: wireless-regdb,              verpat: "(20[0-9]{2})([0-9]{2})([0-9]{2})",         setver: "$1.$2.$3" } # https://git.kernel.org/pub/scm/linux/kernel/git/sforshee/wireless-regdb.git/refs/
 - { name: wireless-tools,              ver: ["29.9","30"],           ruleset: [rpm,kaos,pisi], incorrect: true } # 30pre9, not 30
 - { name: wireless-tools,                                            ruleset: [rpm,kaos,pisi], untrusted: true }


### PR DESCRIPTION
Unable to find 0.0.20231211 release.

Not in tags: https://git.zx2c4.com/wireguard-go/refs/tags

---

The HEAD version from https://git.zx2c4.com/wireguard-go/tree/version.go is:
```go
const Version = "0.0.20230223"
```

And git clone of HEAD then `make` results in binary with
```console
❯ ./wireguard-go --version
wireguard-go v0.0.20230223-46-g12269c2
```