### PR TITLE
passt: unignore official tag scheme

### DIFF
--- a/900.version-fixes/p.yaml
+++ b/900.version-fixes/p.yaml
@@ -36,6 +36,7 @@
 - { name: partitionmanager,            verpat: ".*20[0-9]{6}",                             snapshot: true }
 - { name: partitionmanager,            verpat: "[0-9]+\\.[0-9]+\\.[89][0-9]+",             devel: true }
 - { name: passh,                       verpat: "20[0-9]{2}.*",                             incorrect: true }
+- { name: passt,                       verpat: "[0-9]{4}[._][0-9]{2}[._][0-9]{2}\\.[0-9a-f]{7}", ignore: false, altver: true, any_is_patch: true } # official tags
 - { name: passwdqc,                    verlonger: 3,                 ruleset: sisyphus,    incorrect: true } # sisyphus garbage
 - { name: passwdqc,                                                  ruleset: sisyphus,    untrusted: true } # accused of fake 1.3.1.1, 1.3.1.2
 - { name: password-gorilla,            verlonger: 4,                 ruleset: homebrew_casks, incorrect: true }


### PR DESCRIPTION
Official tags use underscore date with git commit hash: https://passt.top/passt/refs/tags

Upstream uses `git describe --tags HEAD` to embed the version into binaries: https://passt.top/passt/tree/Makefile#n12

---

Not too sure if `altver` works here. Need some details on underscore/dot handling.