### PR TITLE
jellyfish: add github to split

### DIFF
--- a/850.split-ambiguities/j.yaml
+++ b/850.split-ambiguities/j.yaml
@@ -51,7 +51,7 @@
 - { name: jd, wwwpart: [jd4linux,yama-natuki], setname: jd-2ch-browser }
 - { name: jd, addflag: unclassified }
 
-- { name: jellyfish, wwwpart: [genome,cbcb.umd.edu], setname: jellyfish-k-mer }
+- { name: jellyfish, wwwpart: [genome,gmarcais,cbcb.umd.edu], setname: jellyfish-k-mer }
 - { name: jellyfish, wwwpart: [jamesturk,sunlightlabs], setname: "python:jellyfish" }
 - { name: jellyfish, addflag: unclassified }
 


### PR DESCRIPTION
Leftovers at https://repology.org/project/jellyfish-unclassified are all using GitHub repo https://github.com/gmarcais/Jellyfish as homepage