### PR TITLE
pygmo: unmerge from pagmo as not sync'd updates

### DIFF
--- a/800.renames-and-merges/p.yaml
+++ b/800.renames-and-merges/p.yaml
@@ -18,7 +18,6 @@
 - { setname: pactorio,                 name: "rust:pactorio" }
 - { setname: padthv1,                  name: padthv1-lv2 }
 - { setname: pagmo,                    name: pagmo2 }
-- { setname: pagmo,                    name: "python:pygmo", addflavor: pygmo }
 - { setname: paho.mqtt.c,              name: [paho,paho-c,paho-mqtt-c,libpaho-mqtt3,libpaho-mqtt] }
 - { setname: paho.mqtt.cpp,            name: [paho-mqtt-cpp,paho-mqttpp3,paho-cpp] }
 - { setname: paint.net,                name: paintdotnet }


### PR DESCRIPTION
The patch versions are independently updated so tracking these together doesn't provide accurate version information.

For example, C++ `pagmo` **2.19.1** is latest release and is a dependency for `python:pygmo` **2.19.7** (https://esa.github.io/pygmo2/install.html, https://github.com/esa/pygmo2/releases/tag/v2.19.7)

Maybe `python:pygmo` should be same as https://repology.org/project/pygmo and https://repology.org/project/python%3Apygmo2 but this is across various `python-` prefix naming.