### PR TITLE
peg: 0.1.20 is devel

### DIFF
--- a/900.version-fixes/p.yaml
+++ b/900.version-fixes/p.yaml
@@ -97,6 +97,7 @@
 - { name: peazip,                      ver: "9.9.0",                 ruleset: nix,         incorrect: true }
 - { name: peazip,                                                    ruleset: nix,         untrusted: true } # accused of fake 9.9.0
 - { name: peda,                        verlonger: 2,                 ruleset: freebsd,     incorrect: true }
+- { name: peg,                         ver: "0.1.20",                                      devel: true, maintenance: true } # https://www.piumarta.com/software/peg/
 - { name: pencil2d,                    verlonger: 3,                 ruleset: freebsd,     incorrect: true }
 - { name: perf,                        verpat: ".*20[0-9]{2}.*",                           incorrect: true }
 - { name: performous,                  verpat: ".*20[0-9]{2}.*",                           snapshot: true }


### PR DESCRIPTION
According to https://www.piumarta.com/software/peg/
> The development version is 0.1.20 and is updated periodically. If you want to help find bugs please try it out. A tarball is linked in the version history.

No easy way to distinguish the development version.