### PR TITLE
watcher: split

### DIFF
--- a/850.split-ambiguities/w.yaml
+++ b/850.split-ambiguities/w.yaml
@@ -21,6 +21,11 @@
 - { name: warp, wwwpart: reverbrain, setname: warp-word-analysis }
 - { name: warp, addflag: unclassified }
 
+- { name: watcher, wwwpart: e-dant, setname: wtr-watcher }
+- { name: watcher, wwwpart: openstack, setname: openstack-watcher }
+- { name: watcher, wwwpart: radovskyb, setname: watcher-go }
+- { name: watcher, addflag: unclassified }
+
 - { name: watson, wwwpart: [tailordev/watson, jazzband.github.io], setname: watson-time-tracling-cli }
 - { name: watson, addflag: unclassified }
 


### PR DESCRIPTION
Splitting https://repology.org/project/watcher
* https://github.com/e-dant/watcher - seems to use `wtr-watcher` when there is conflicting names like on PyPI (https://pypi.org/project/wtr-watcher/) and Crates (https://crates.io/crates/wtr-watcher)
* https://github.com/openstack/watcher - I saw multiple Repology projects prepend `openstack-` for splits so used `openstack-watcher`.
* https://github.com/radovskyb/watcher - not too sure on this one. Just appended `-go` for now