### PR TITLE
amethyst: split

### DIFF
--- a/850.split-ambiguities/a.yaml
+++ b/850.split-ambiguities/a.yaml
@@ -190,6 +190,11 @@
 - { name: amd, wwwpart: plosone, setname: amd-automated-motif-discovery }
 - { name: amd, wwwpart: am-utils, setname: am-utils }
 
+- { name: amethyst, wwwpart: ianyh, addflag: classified }
+- { name: amethyst, wwwpart: Geoxor, setname: amethyst-player }
+- { name: amethyst, wwwpart: neoninteger, setname: amethyst-editor }
+- { name: amethyst, addflag: unclassified }
+
 - { name: amp, wwwpart: [amp.rs, jmacdonald/amp], setname: amp-editor }
 - { name: amp, wwwpart: andrewpeterson, setname: amp-machinelearning }
 - { name: amp, addflag: unclassified }


### PR DESCRIPTION
Splitting https://repology.org/project/amethyst

- https://github.com/ianyh/Amethyst kept original name
- https://codeberg.org/neoninteger/amethyst seems to be text editor so appended `-editor` for now
- https://github.com/Geoxor/Amethyst is also using `amethyst-player` (https://repology.org/project/amethyst-player)