### PR TITLE
Renames for 'win32api-{headers,runtime}' cygwin packages

### DIFF
--- a/440.mingw.yaml
+++ b/440.mingw.yaml
@@ -44,3 +44,6 @@
 - { addflag: not_unmingw,              name: "mingw:w64-tools" }
 
 - { setname: "$1", noflag: not_unmingw, namepat: "mingw:(.*)", addflavor: mingw }
+
+# these are unflavoured packages on cygwin, for cygwin toolchain access to Win32 API
+- { setname: mingw:$1,                 namepat: "win32api-(headers|runtime)", ruleset: [cygwin] }


### PR DESCRIPTION
`win32api-{headers,runtime}` is the same upstream project as `mingw64-{i686,x86_64}-{headers,runtime}`, called
`mingw:{headers,runtime}` in repology, but these are the unflavoured packages, used when compiling Cygwin-hosted executables (rather than cross-compiling Windows executables).