### PR TITLE
libgedit-amtk, libgedit-tepl: merge

### DIFF
--- a/800.renames-and-merges/a.yaml
+++ b/800.renames-and-merges/a.yaml
@@ -181,7 +181,6 @@
 - { setname: ammonite,                 name: ammonite-repl }
 - { setname: amp-editor,               name: "rust:amp" }
 - { setname: ampy,                     name: ["python:adafruit-ampy","python:ampy",adafruit-ampy], wwwpart: adafruit }
-- { setname: amtk,                     name: lib$0 }
 - { setname: amule,                    name: [amule-daemon,amule-gui], addflavor: true }
 - { setname: amule,                    name: amule-devel, weak_devel: true, nolegacy: true }
 - { setname: amzn-drivers,             name: [ena, dkms-ena, ena-driver], addflavor: true }

--- a/800.renames-and-merges/l.yaml
+++ b/800.renames-and-merges/l.yaml
@@ -68,6 +68,8 @@
 - { setname: lexicon,                  name: ["python:dns-lexicon", dns-lexicon] }
 - { setname: lgogdownloader,           name: lgogdownloader-qt5, addflavor: true }
 - { setname: liberal-crime-squad,      name: [lcs,liberalcrimesquad] }
+- { setname: libgedit-amtk,            namepat: "(?:lib)?amtk[0-9.-]*" }
+- { setname: libgedit-tepl,            namepat: "(?:lib)?tepl[0-9.-]*" }
 - { setname: libreoffice,              name: [libreoffice-bin,libreoffice-bin-debug,libreoffice-gtk3], addflavor: true }
 - { setname: libreoffice,              name: [libreoffice-dev,libreoffice-fresh,libreoffice-oldstable,libreoffice-still,libreoffice-stable] }
 - { setname: libreoffice,              namepat: "([^-]+)-libreoffice", ruleset: freebsd, addflavor: $1 }

--- a/800.renames-and-merges/t.yaml
+++ b/800.renames-and-merges/t.yaml
@@ -85,7 +85,6 @@
 - { setname: tensorflow,               name: [python:tensorflow, python:tensorflow2] } # but not python:tensorflow1
 - { setname: tensorflow,               name: [python:tensorflow-cpu, python:tensorflow-gpu, python:tensorflow-lite, tensorflow-cc, tensorflow-common], addflavor: true }
 - { setname: tensorflow,               name: libtensorflow1-noavx, addflavor: noavx }
-- { setname: tepl,                     namepat: "(?:lib)?tepl[0-9.-]*" }
 - { setname: terminal-image-viewer,    name: terminalimageviewer }
 - { setname: terminal-markdown-viewer, name: mdv }
 - { setname: termtosvg,                name: "python:termtosvg" }


### PR DESCRIPTION
amtk was renamed to libgedit-amtk and tepl was renamed to libgedit-tepl upstream: [git repos](https://gitlab.gnome.org/World/gedit) and [homepage](https://gedit-text-editor.org/technology.html).

Here's my attempt at merging this.