### PR TITLE
ocaml:*: mark date-stamped snapshots incorrect

### DIFF
--- a/900.version-fixes/o.yaml
+++ b/900.version-fixes/o.yaml
@@ -32,6 +32,7 @@
 - { name: "ocaml:qcheck-rely",          verpat: "20[0-9]{2}-[0-9]{2}-[0-9]{2}.*", ruleset: nix, incorrect: true } # accused of fake 2022-08-31-a0ddab6
 - { name: "ocaml:refmterr",             verpat: "20[0-9]{2}-[0-9]{2}-[0-9]{2}.*", ruleset: nix, incorrect: true } # accused of fake 2022-08-31-a0ddab6
 - { name: "ocaml:rely",                 verpat: "20[0-9]{2}-[0-9]{2}-[0-9]{2}.*", ruleset: nix, incorrect: true } # accused of fake 2022-08-31-a0ddab6
+- { name: "ocaml:rely-junit-reporter",  verpat: "20[0-9]{2}-[0-9]{2}-[0-9]{2}.*", ruleset: nix, incorrect: true } # accused of fake 2022-08-31-a0ddab6
 - { name: "ocaml:sexplib",             ver: "7.0.5",                 ruleset: fedora,      incorrect: true }
 - { name: "ocaml:sexplib",                                           ruleset: fedora,      untrusted: true } # accused of fake 7.0.5
 - { name: "ocaml:sexplib",             verge: "100",                                       sink: true } # ... -> 113.x → 0.9.0


### PR DESCRIPTION
These packages were versioned as `YYYYY-MM-DD-*` in past nixpkgs, but are now versioned as `version-unstable-YYYYY-MM-DD` for correct version comparison. OCaml packages that could not list outdate packages correctly due to past versioning have been fixed.

- [x] `make check`