### PR TITLE
Add rename rule simpl-sim → simplc

### DIFF
--- a/800.renames-and-merges/s.yaml
+++ b/800.renames-and-merges/s.yaml
@@ -181,6 +181,7 @@
 - { setname: simage,                   name: libsimage }
 - { setname: simdjson,                 name: lib$0 }
 - { setname: simh,                     name: simh-classic, addflavor: true }
+- { setname: simplc,                   name: simpl-sim }
 - { setname: simple-components,        name: kazakov-simple-components }
 - { setname: simple-scan,              name: simple-scan-3.12 }
 - { setname: simple-scan,              name: simple-scan-trunk, ignore: true }


### PR DESCRIPTION
The normalized name matches the actual project's name, and the identifier at sourceforge: https://sourceforge.net/projects/simpl/