### PR TITLE
pakku: split

### DIFF
--- a/850.split-ambiguities/p.yaml
+++ b/850.split-ambiguities/p.yaml
@@ -41,6 +41,10 @@
 # also unprefixed python module
 - { name: paho-mqtt, addflag: unclassified }
 
+- { name: pakku, wwwpart: juraj-hrivnak, setname: $0-minecraft }
+- { name: pakku, wwwpart: zqqw, setname: $0-pacman }
+- { name: pakku, addflag: unclassified }
+
 - { name: pal, wwwpart: palcal, setname: palcal }
 - { name: pal, wwwpart: starlink, setname: pal-astronomical }
 - { name: pal, ruleset: cygwin, setname: palcal }


### PR DESCRIPTION
Splitting [pakku](https://repology.org/project/pakku) as one is a Minecraft modpack manager and the other is a Pacman wrapper with AUR support. 

  - https://github.com/juraj-hrivnak/Pakku  - added `-minecraft` as its related to Minecraft  
  - https://github.com/zqqw/pakku - added `-pacman` as its related to the Pacman package managment