### PR TITLE
antares: split; merge -sql-beta into -sql

### DIFF
--- a/800.renames-and-merges/a.yaml
+++ b/800.renames-and-merges/a.yaml
@@ -212,6 +212,8 @@
 - { setname: ansible-lint,             name: "python:ansible-lint" }
 - { setname: ansible-runner,           name: "python:ansible-runner" }
 - { setname: ant,                      name: ant-junit5, addflavor: true }
+- { setname: antares,                  name: antares-sql }
+- { setname: antares,                  name: antares-sql-beta, weak_devel: true, nolegacy: true }
 - { setname: anthy,                    name: libanthy }
 - { setname: antidote,                 name: zsh-antidote }
 - { setname: antimicro,                name: antimicro-qt4 }

--- a/850.split-ambiguities/a.yaml
+++ b/850.split-ambiguities/a.yaml
@@ -214,6 +214,11 @@
 - { name: annotator, wwwpart: snijderlab, setname: annotator-mass-spectrometry }
 - { name: annotator, addflag: unclassified }
 
+- { name: antares, wwwpart: arescentral, setname: antares-game }
+- { name: antares, wwwpart: [antares-sql,Fabio286], setname: antares-sql }
+# also X window manager with dead upstream
+- { name: antares, addflag: unclassified }
+
 - { name: antidote, wwwpart: [getantidote.github.io,mattmc3], setname: antidote-zsh-plugin-manager }
 - { name: antidote, addflag: unclassified }
 


### PR DESCRIPTION
Splitting https://repology.org/project/antares

- https://arescentral.org/antares - appended `-game` since that seems to be how other splits do it
- https://antares-sql.app/ - appended `-sql` to match the existing [`antares-sql`](https://repology.org/project/antares-sql) found in AUR

Also merged https://repology.org/project/antares-sql-beta found on AUR into the latter.