### PR TITLE
Added 'feature branch' merge for nvidia

### DIFF
--- a/800.renames-and-merges/nvidia.yaml
+++ b/800.renames-and-merges/nvidia.yaml
@@ -18,6 +18,7 @@
 - { setname: nvidia,                   name: nvidia-current, weak_devel: true, nolegacy: true }
 - { setname: nvidia,                   name: nvidia-developer-driver, weak_devel: true, nolegacy: true }
 - { setname: nvidia,                   namepat: "nvidia-drivers?[x0-9.-]*" }
+- { setname: nvidia,                   name: nvidia-fb }
 - { setname: nvidia,                   name: nvidia-fbcondecor, addflavor: true }
 - { setname: nvidia,                   name: nvidia-full-beta, weak_devel: true, nolegacy: true }
 - { setname: nvidia,                   name: nvidia-full-beta-all, weak_devel: true, nolegacy: true, addflavor: all }


### PR DESCRIPTION
CRUX supports both the 'production branch' (named nvidia) and 'feature branch' (named nvidia-fb) packages for NVIDIA graphics drivers.

Is this the appropriate way to merge them?