### PR TITLE
libmemcached{,-awesome}: merge

### DIFF
--- a/800.renames-and-merges/l.yaml
+++ b/800.renames-and-merges/l.yaml
@@ -68,6 +68,7 @@
 - { setname: lexicon,                  name: ["python:dns-lexicon", dns-lexicon] }
 - { setname: lgogdownloader,           name: lgogdownloader-qt5, addflavor: true }
 - { setname: liberal-crime-squad,      name: [lcs,liberalcrimesquad] }
+- { setname: libmemcached,             name: [libmemcached-awesome] }
 - { setname: libreoffice,              name: [libreoffice-bin,libreoffice-bin-debug,libreoffice-gtk3], addflavor: true }
 - { setname: libreoffice,              name: [libreoffice-dev,libreoffice-fresh,libreoffice-oldstable,libreoffice-still,libreoffice-stable] }
 - { setname: libreoffice,              namepat: "([^-]+)-libreoffice", ruleset: freebsd, addflavor: $1 }


### PR DESCRIPTION
Cf. https://repology.org/projects/?search=libmemcached

*For versions newer than 1.0.18*, upstream is https://github.com/awesomized/libmemcached which
is a "Resurrection of libmemcached".
Older versions are from https://libmemcached.org/libMemcached.html and stop here: https://launchpad.net/libmemcached/+download

CMake config install dir is "libmemcached-awesome", probably to clearly disambiguate from the original project and from "memcached" (https://github.com/memcached/memcached) which is a related but different project.

Alternative (but not yet in my skills): Map to libmemcached-awesome what is using the newer upstream.