### PR TITLE
hexdiff: split

### DIFF
--- a/850.split-ambiguities/h.yaml
+++ b/850.split-ambiguities/h.yaml
@@ -74,6 +74,10 @@
 - { name: hexd, wwwpart: fireyfly, setname: hexd-fireyfly }
 - { name: hexd, addflag: unclassified }
 
+- { name: hexdiff, wwwpart: tboudet, setname: visual-hexdiff }
+- { name: hexdiff, wwwpart: ahroach, setname: hexdiff-ahroach }
+- { name: hexdiff, addflag: unclassified }
+
 - { name: hexdump, wwwpart: esr, setname: hexd-esr }
 - { name: hexdump, addflag: unclassified }
 


### PR DESCRIPTION
Splitting https://repology.org/project/hexdiff/

- https://github.com/ahroach/hexdiff is terminal program that compares two binary files
- http://tboudet.free.fr/hexdiff/ is also a terminal program that compares two binary files. However, it differs in name (referred to as visual-hexdiff)

`hexdiff-ahroach` =/= `visual-hexdiff`, thus they should be split.