### PR TITLE
piper-tts: extend the split to include the new repo

### DIFF
--- a/850.split-ambiguities/p.yaml
+++ b/850.split-ambiguities/p.yaml
@@ -182,7 +182,7 @@
 
 - { name: piper, wwwpart: qwirx.com, setname: piper-socks5-manipulator }
 - { name: piper, wwwpart: libratbag, setname: piper-mice-configurator }
-- { name: piper, wwwpart: rhasspy, setname: piper-tts }
+- { name: piper, wwwpart: [OHF-Voice,rhasspy], setname: piper-tts }
 - { name: piper, addflag: unclassified }
 
 - { name: piranha, wwwpart: bluescarni, setname: piranha-algebra }


### PR DESCRIPTION
The development of the package has moved to https://github.com/OHF-Voice/piper1-gpl.