### PR TITLE
eden: split on `wwwpart: eden-emu`

### DIFF
--- a/850.split-ambiguities/e.yaml
+++ b/850.split-ambiguities/e.yaml
@@ -28,6 +28,7 @@
 
 - { name: eden, wwwpart: starkandwayne, setname: eden-openservicebrokerapi }
 - { name: eden, wwwpart: gromacs, setname: eden-crystallography }
+- { name: eden, wwwpart: eden-emu, setname: eden-emulator }
 - { name: eden, addflag: unclassified }
 
 - { name: edge, sourceforge: edge, setname: edge-engine }


### PR DESCRIPTION
There is an emulator with the same name: https://eden-emu.dev.