### PR TITLE
mcl: split on `mcl-algorithm` and `mcl-cpp`

### DIFF
--- a/850.split-ambiguities/m.yaml
+++ b/850.split-ambiguities/m.yaml
@@ -107,6 +107,10 @@
 - { name: mcedit, wwwpart: mcedit-unified, setname: mcedit-unified }
 - { name: mcedit, addflag: unclassified }
 
+- { name: mcl, wwwpart: micans, setname: mcl-graph-clustering }
+- { name: mcl, wwwpart: merryhime, setname: mcl-c++-utility-lib }
+- { name: mcl, addflag: unclassified }
+
 - { name: mcs, wwwpart: go-mono, setname: mcs-mono-compiler }
 - { name: mcs, wwwpart: [atheme,nenolod], setname: mcs-modular-config-system }
 - { name: mcs, addflag: unclassified }


### PR DESCRIPTION
Merry's common library has the same name: https://github.com/merryhime/mcl.