### PR TITLE
supabase: mark nix untrusted

### DIFF
--- a/900.version-fixes/s.yaml
+++ b/900.version-fixes/s.yaml
@@ -431,6 +431,8 @@
 - { name: sunxi-tools,                 ver: "1.5",                   ruleset: sisyphus,    incorrect: true }
 - { name: sunxi-tools,                                               ruleset: sisyphus,    untrusted: true } # accused of fake 1.5
 - { name: suomi-malaga,                verge: "2",                                         incorrect: true } # https://voikko.puimula.org/sources.html, https://www.puimula.org/voikko-sources/suomi-malaga/: 2.0 has different name
+- { name: supabase,                    ver: "2.36.2",                ruleset: nix,         incorrect: true }
+- { name: supabase,                                                  ruleset: nix,         untrusted: true } # fake 2.6.32
 - { name: superfile,                   ver: "1.1.3.0.20240512232412",                      incorrect: true, sink: true } # commit before 1.1.3
 - { name: superfile,                                                 ruleset: freebsd,     untrusted: true } # accused of fake 1.1.3.0.20240512232412
 - { name: superiotool,                 verpat: "20[0-9]{6}",                               incorrect: true }


### PR DESCRIPTION
The nix repo [nixpkgs unstable](https://repology.org/repository/nix_unstable) holds pre-releases, and [supabase](https://repology.org/project/supabase/versions) has no way to know which versions are pre-releases from the version. For instance currently all repos holding the latest stable version 2.34.3 are marked outdated because nixpkgs unstable has 2.36.2 which is a pre-release.

I don't know repology well, there may be better solutions, namely:

- only ignoring the unstable repo for nix; or
- getting the info from GitHub.

However I know how to do neither of those.