### PR TITLE
zycore-c: merge into `zycore`

### DIFF
--- a/800.renames-and-merges/z.yaml
+++ b/800.renames-and-merges/z.yaml
@@ -85,5 +85,6 @@
 - { setname: zulu,                     name: [zulu-ca-jdk, zulu-embedded-jdk, zulu-jdk-fx, zulu-jre-fx], addflavor: true }
 - { setname: zvbi,                     name: libzvbi }
 - { setname: zxing-cpp,                name: [libzxing-cpp,nu-book-zxing-cpp,zxing-cpp-nu] }
+- { setname: zycore,                   name: zycore-c }
 - { setname: zynaddsubfx,              name: [zynaddsubfx-doc,zynaddsubfx-fusion], addflavor: true }
 - { setname: zziplib,                  name: libzzip }


### PR DESCRIPTION
It seems that the canonical name of the project is indeed Zycore.

See https://github.com/zyantific/zycore-c.