### PR TITLE
vulkanmemoryallocator: merge into `vulkan-memory-allocator`.

### DIFF
--- a/800.renames-and-merges/v.yaml
+++ b/800.renames-and-merges/v.yaml
@@ -110,6 +110,7 @@
 - { setname: vulkan-caps-viewer,       name: [vulkan-caps-viewer-wayland,vulkan-caps-viewer-x11], addflavor: true }
 - { setname: vulkan-extensionlayer,    name: vulkan-extension-layer }
 - { setname: vulkan-loader,            name: vulkan-icd-loader }
+- { setname: vulkan-memory-allocator,  name: vulkanmemoryallocator }
 - { setname: vulkan-sdk,               name: vulkan-sdk-bin, addflavor: bin }
 - { setname: vulkan-sdk,               name: vulkansdk }
 - { setname: vulkan-validationlayers,  name: [vulkan-validation-layers,vulkan-layers] }


### PR DESCRIPTION
That way, the name of the project is more readable.