### PR TITLE
libsonic: merge into `sonic`

### DIFF
--- a/800.renames-and-merges/s.yaml
+++ b/800.renames-and-merges/s.yaml
@@ -279,6 +279,7 @@
 - { setname: sonarqube,                name: sonarqube-community }
 - { setname: sonarr,                   name: $0-bin, addflavor: true }
 - { setname: sonarr,                   name: $0-develop, weak_devel: true, nolegacy: true }
+- { setname: sonic,                    name: libsonic }
 - { setname: sonic-pi,                 name: sonicpi }
 - { setname: sonic-visualiser,         name: sonicvisualiser }
 - { setname: sonivox-eas,              name: sonivoxeas }


### PR DESCRIPTION
This should put it in `sonic-speech-rate-library` afterwards.