### PR TITLE
choose-rust: split and merge

### DIFF
--- a/800.renames-and-merges/c.yaml
+++ b/800.renames-and-merges/c.yaml
@@ -176,6 +176,7 @@
 - { setname: chipmunk,                 name: cmonk, addflavor: true } # duplicate package in aur, avoid legacy status
 - { setname: chirp,                    name: [chirp-next, chirp-daily] }
 - { setname: chmlib,                   name: libchm }
+- { setname: choose,                   name: ["rust:choose", choose-rust] }
 - { setname: chowtapemodel,            name: chow-tape-model }
 - { setname: chr,                      name: chr-editor }
 - { setname: chromaprint,              name: [chromaprint-fftw, chromaprint-tools, libchromaprint], addflavor: true }

--- a/850.split-ambiguities/c.yaml
+++ b/850.split-ambiguities/c.yaml
@@ -194,6 +194,10 @@
 - { name: chisel, wwwpart: facebook, setname: $0-lldb-ios-debugging }
 - { name: chisel, addflag: unclassified }
 
+- { name: choose, wwwpart: theryangeary, setname: choose-cut }
+- { name: choose, wwwpart: geier, setname: choose-cli-choice }
+- { name: choose, addflag: unclassified }
+
 - { name: chroma, setname: "go:github-alecthomas-chroma", wwwpart: alecthomas }
 
 - { name: chromium, wwwpart: bsu, setname: chromium-bsu } # XXX: problem


### PR DESCRIPTION
Merging https://repology.org/project/choose/versions

- https://github.com/theryangeary/choose is the correct homepage and upstream
- `choose` and `choose-rust` are the same package (Homebrew and AUR use choose-rust)
- `rust:choose` is another reference of the same package, from https://crates.io/crates/choose

(`rust:choose` == `choose-rust`)  =/= [`choose`](https://github.com/geier/choose), thus they should be split into `choose` and `choose-rust`