### PR TITLE
libfaketime: merge

### DIFF
--- a/800.renames-and-merges/lib.yaml
+++ b/800.renames-and-merges/lib.yaml
@@ -90,6 +90,7 @@
 - { setname: libevent,                 name: [libevent-fb,libevent-hiphop,libeventextra], addflavor: true }
 - { setname: libewf,                   name: libewf-legacy }
 - { setname: libexif-gtk,              name: libexif-gtk3, addflavor: true }
+- { setname: libfaketime,              name: faketime }
 - { setname: libfame,                  name: libfame-0-9-1 }
 - { setname: libfastjson,              name: fastjson }
 - { setname: libffi,                   namepat: "libffi[0-9.-]+" }


### PR DESCRIPTION
Merging https://repology.org/project/libfaketime/related

- libfaketime is the name of the project [hosted on Github](https://github.com/wolfcw/libfaketime)
- faketime is a name referring to the CLI provided by libfaketime

`libfaketime` == `faketime`, thus they should be merged