### PR TITLE
android-simg2img: merge

### DIFF
--- a/800.renames-and-merges/a.yaml
+++ b/800.renames-and-merges/a.yaml
@@ -191,6 +191,7 @@
 - { setname: anacron2,                 name: anacron, verpat: "2\\.[4-9].*" } # different project (a fork?)
 - { setname: anari-sdk,                name: anari }
 - { setname: android-file-transfer,    name: [android-file-transfer-linux,android-file-transfer-qt4,android-file-transfer-qt5], addflavor: true }
+- { setname: android-simg2img,         name: simg2img }
 - { setname: android-studio,           name: [android-studio-beta,android-studio-canary,android-studio-dummy,android-studio-preview,android-studio-dev,androidstudio.beta,androidstudio.canary], weak_devel: true, nolegacy: true } # these could be devel, but they do often fall behind, and due to viral devel property be safe and ignore them
 - { setname: android-studio,           name: [android-studio-ide,android-studio-stable,androidstudio] }
 - { setname: android-studio-tools,     name: [android-clt, android-commandlinetools]}


### PR DESCRIPTION
Merging https://repology.org/project/android-simg2img/related

- android-simg2img is the name of the project [hosted on GitHub](https://github.com/anestisb/android-simg2img)
- simg2img is the name of a CLI provided by android-simg2img

`android-simg2img` == `simg2img`, thus they should be merged