### PR TITLE
Merge Freifunk gluon rust tools

### DIFF
--- a/800.renames-and-merges/rust.yaml
+++ b/800.renames-and-merges/rust.yaml
@@ -4,6 +4,7 @@
 - { setname: "rust:cargo-asm",         name: cargo-asm }
 - { setname: "rust:crossterm",         namepat: "rust:crossterm[0-9.]+" }
 - { setname: "rust:getopts",           name: rust-getopts } # XXX: replace with wildcard?
+- { setname: "rust:gluon-mesh-vpn-key-translate", name: gluon-mesh-vpn-key-translate }
 - { setname: "rust:lolcat",            name: lolcat-rs }
 - { setname: "rust:simple-http-server", name: simple-http-server }
 - { setname: "rust:xsv",               name: xsv-rs }

--- a/800.renames-and-merges/rust.yaml
+++ b/800.renames-and-merges/rust.yaml
@@ -5,6 +5,7 @@
 - { setname: "rust:crossterm",         namepat: "rust:crossterm[0-9.]+" }
 - { setname: "rust:getopts",           name: rust-getopts } # XXX: replace with wildcard?
 - { setname: "rust:gluon-mesh-vpn-key-translate", name: gluon-mesh-vpn-key-translate }
+- { setname: "rust:gluon-node-sense",  name: gluon-node-sense }
 - { setname: "rust:lolcat",            name: lolcat-rs }
 - { setname: "rust:simple-http-server", name: simple-http-server }
 - { setname: "rust:xsv",               name: xsv-rs }


### PR DESCRIPTION
Reading through #558, it appears applications that are on https://crates.io land in a `rust:` prefixed namespace?

I hope these two commits allow for this two applications to show up in repologys usual search.

*Not sure whether this is really considered a `merge` as the projects are currently only packaged in https://crates.io.*