### PR TITLE
uradvd: revert and merge

### DIFF
--- a/800.renames-and-merges/u.yaml
+++ b/800.renames-and-merges/u.yaml
@@ -87,6 +87,7 @@
 - { setname: upscayl,                  name: upscayl-rpm, addflavor: true }
 - { setname: upx,                      name: upx-ucl, addflavor: true }
 - { setname: uqm,                      name: [uqm-3domusic,uqm-content,uqm-voice], addflavor: true }
+- { setname: uradvd,                   namepat: "uradvd[0-9.-]+" }
 - { setname: urbanterror,              name: urban-terror }
 - { setname: urbanterror,              name: urbanterror-data, addflavor: true }
 - { setname: urdfdom,                  name: ros-urdfdom }

--- a/900.version-fixes/u.yaml
+++ b/900.version-fixes/u.yaml
@@ -75,7 +75,6 @@
 - { name: upower,                      ver: "1.90.7.13",                                   incorrect: true } # opensuse
 - { name: upower,                                                    ruleset: opensuse,    untrusted: true } # accused of fake 1.90.7.13
 - { name: uqm,                         vereq: "0.7.0.1",                                   setver: "0.7.0" } # only cosmetic changes to source
-- { name: uradvd,                                                                          noscheme: true }
 - { name: urbanterror,                 verpat: "[0-9]+",                                   incorrect: true }
 - { name: urbanterror,                 verpat: ".*20[0-9]{6}",                             snapshot: true }
 - { name: urlview,                     verpat: ".*20[0-9]{6}",                             snapshot: true }


### PR DESCRIPTION
I'm not sure how I can mark the official version scheme,
but `uradvd` provides `make version` which emits the current official version.

The current version is `r26-1e64364d`.

The program started versioning in this week, let me know if I missed something :)