### PR TITLE
gitu: merge

### DIFF
--- a/800.renames-and-merges/g.yaml
+++ b/800.renames-and-merges/g.yaml
@@ -174,6 +174,7 @@
 - { setname: gitolite,                 name: [gitolite2,gitolite3] }
 - { setname: gitter,                   name: gitter-bin }
 - { setname: gitter-cli,               name: "node:gitter-cli" }
+- { setname: gitu,                     name: rust:$0 }
 - { setname: gitui,                    name: rust:$0 }
 - { setname: givaro,                   name: lib$0 }
 - { setname: gixy,                     name: "python:gixy" }


### PR DESCRIPTION
Merging https://repology.org/project/gitu/related

- `gitu` is a TUI Git client
- `rust:gitu` is the crate to the same project, which is installed using `cargo`

`gitu` == `rust:gitui`, thus it should be merged