### PR TITLE
gossip: extend split on wwwpart: [gnome,imendio]

### DIFF
--- a/850.split-ambiguities/g.yaml
+++ b/850.split-ambiguities/g.yaml
@@ -240,6 +240,7 @@
 
 - { name: gossip, wwwpart: jdillon, setname: gossip-slf4j }
 - { name: gossip, wwwpart: mikedilger, setname: gossip-nostr }
+- { name: gossip, wwwpart: [gnome,imendio], setname: gnome-gossip }
 - { name: gossip, addflag: unclassified }
 
 - { name: gosu, wwwpart: tianon, setname: gosu-su }


### PR DESCRIPTION
As there is a jabber client from the gnome project, see https://wiki.gnome.org/Attic(2f)Gossip.html
imendio is part of the old project homepage, gnome of the newer.

Named `gnome-gossip` as the other gnome projects are usually named like this gnome-xx.