### PR TITLE
colo: extend split on wwwpart: [cobalt,clfs]

### DIFF
--- a/850.split-ambiguities/c.yaml
+++ b/850.split-ambiguities/c.yaml
@@ -344,6 +344,7 @@
 - { name: cog, addflag: unclassified }
 
 - { name: colo, wwwpart: aloso.github.io/colo/, setname: $0-color-management-tui }
+- { name: colo, wwwpart: [cobalt,clfs], setname: colo-boot }
 # also mips bootloader with dead upstream
 - { name: colo, addflag: unclassified }
 


### PR DESCRIPTION
As colo is also a bootloader for cobalt linux, the download is offered in the context of cross linux from scratch (clfs) 
see also [clfs-doc](https://clfs.org/view/sysvinit/mips/bootable/colo.html) / [clfs-download](https://ftp2.osuosl.org/pub/clfs/clfs-packages/git/) there is also a homepage from the [webarchive](https://web.archive.org/web/20250419165403/http://colonel-panic.org/cobalt-mips/).