### PR TITLE
Merge gnome-notes into bijiben

### DIFF
--- a/800.renames-and-merges/b.yaml
+++ b/800.renames-and-merges/b.yaml
@@ -104,6 +104,7 @@
 - { setname: bibtool,                  name: bib-tool }
 - { setname: bicep,                    name: [bicep-langserver, bicep-lsp], addflavor: lsp }
 - { setname: bicyclerepair,            name: bicyclerepair-py27 }
+- { setname: bijiben,                  name: gnome-notes } # https://gitlab.gnome.org/Infrastructure/Infrastructure/-/issues/2095
 - { setname: billardgl,                name: billard-gl }
 - { setname: bin,                      name: bin-github } # XXX: naming wtf
 - { setname: bincimap,                 name: bincimap12 }


### PR DESCRIPTION
bijiben was partially renamed to gnome-notes years ago but the project is now officially bijiben

https://gitlab.gnome.org/Infrastructure/Infrastructure/-/issues/2095