### PR TITLE
hyfetch: merge

### DIFF
--- a/800.renames-and-merges/h.yaml
+++ b/800.renames-and-merges/h.yaml
@@ -124,7 +124,7 @@
 - { setname: hydra,                    name: thc-hydra }
 - { setname: hydralauncher,            name: hydra-launcher }
 - { setname: hydrus,                   name: [hydrus-network, "python:hydrus"] }
-- { setname: hyfetch,                  name: python:$0 }
+- { setname: hyfetch,                  name: [python:$0, rust:$0] }
 - { setname: hylafax+,                 name: hylafaxplus }
 - { setname: hyperfine,                name: rust:$0 }
 - { setname: hyphen,                   name: lib$0 }


### PR DESCRIPTION
Merging https://repology.org/project/hyfetch/related

- `hyfetch` is a system info utility that mirrors `neofetch`, but with pride flags, written in Rust
- `rust:hyfetch` references the Rust crate, which can be installed using `cargo`

`hyfetch` == `rust:hyfetch`, thus they should be merged