### PR TITLE
minisat: merge

### DIFF
--- a/800.renames-and-merges/m.yaml
+++ b/800.renames-and-merges/m.yaml
@@ -244,6 +244,7 @@
 - { setname: minetest-mineclone5,      name: mineclone-5 }
 - { setname: ming,                     name: libming }
 - { setname: miniaudicle,              name: mini-audicle } # XXX problem, incorrect name
+- { setname: minisat,                  name: [libminisat, minisat2] }
 - { setname: miniserve,                name: "rust:miniserve" }
 - { setname: miniupnpc,                name: "python:miniupnpc", addflavor: python }
 - { setname: miniupnpc,                name: miniupnpc16 }


### PR DESCRIPTION
Merging https://repology.org/project/minisat/related

- `minisat` is a compact and readable [SAT solver](https://en.wikipedia.org/wiki/SAT_solver), hosted on [GitHub](https://github.com/niklasso/minisat)
- `minisat2` is a reference to the same project, whose homepage is http://minisat.se/
- `libminisat` is a reference to the library of the same project
- The blessed upstream by many other packages (e.g, nixpkgs, Homebrew) is [stp/minisat](https://github.com/stp/minisat), which provide both `minisat` and `libminisat`

`minisat2` == `libminisat`, and given that most packagers reference the right homepage, they should be merged into `minisat`