### PR TITLE
pakku-minecraft: merge

### DIFF
--- a/800.renames-and-merges/p.yaml
+++ b/800.renames-and-merges/p.yaml
@@ -22,7 +22,7 @@
 - { setname: paho.mqtt.cpp,            name: [paho-mqtt-cpp,paho-mqttpp3,paho-cpp] }
 - { setname: paint.net,                name: paintdotnet }
 - { setname: paintown,                 name: paintown-data, addflavor: true }
-- { setname: pakku-minecraft,          name: pakku-mc }
+- { setname: pakku,                    name: pakku-mc }
 - { setname: pam,                      name: [libpam,linux-pam] }
 - { setname: pam,                      name: pam-selinux, addflavor: true }
 - { setname: pam-ccreds,               name: libpam-ccreds }


### PR DESCRIPTION
Merging https://repology.org/project/pakku-mc into `pakku`
