### PR TITLE
rename vencord-desktop to vesktop

### DIFF
--- a/800.renames-and-merges/v.yaml
+++ b/800.renames-and-merges/v.yaml
@@ -38,6 +38,7 @@
 - { setname: veloren,                  name: veloren-nightly, weak_devel: true, nolegacy: true }
 - { setname: ventoy,                   name: ventoy-bin, addflavor: true }
 - { setname: vert.x,                   name: vertx }
+- { setname: vesktop,                  name: vencord-desktop }
 - { setname: veusz,                    name: "python:veusz" }
 - { setname: veyon,                    name: [italc,italc1,italc2] } # former name
 - { setname: vhba,                     name: [vhba-module, dkms-vhba, vhba-module-dkms, vhba-kmp] }


### PR DESCRIPTION
project was renamed upstream. see https://github.com/Vencord/Vesktop/pull/57.