### PR TITLE
afsctool: merge

### DIFF
--- a/800.renames-and-merges/a.yaml
+++ b/800.renames-and-merges/a.yaml
@@ -103,6 +103,7 @@
 - { setname: afl++,                    name: aflplusplus }
 - { setname: afl++,                    name: libdislocator, addflavor: true } # part of
 - { setname: afl++,                    name: afl++-llvm, addflavor: true } # XXX: FreeBSD, misnamed
+- { setname: afsctool,                 name: afscompress }
 - { setname: aften,                    name: libaften }
 - { setname: afterstep,                name: afterstep1 }
 - { setname: agar,                     name: libagar }


### PR DESCRIPTION
Merging https://repology.org/project/afsctool/related

- `afsctool` is a utility for manipulating HFS+ compressed files
- `afscompress` is an improved version of the same project, but maintain backwards compatibility with the legacy version

Generally, they're considered to be the same project (with `afscompress` having APFS support for newer macOS versions), thus they should be merged into `afsctool`