### PR TITLE
yojimbo: split

### DIFF
--- a/850.split-ambiguities/y.yaml
+++ b/850.split-ambiguities/y.yaml
@@ -27,6 +27,10 @@
 - { name: yj, wwwpart: sclevine, setname: yj-sclevine }
 - { name: yj, addflag: unclassified }
 
+- { name: yojimbo, wwwpart: barebones, setname: yojimbo-organizer }
+- { name: yojimbo, wwwpart: mas-banwidth, setname: yojimbo-lib }
+- { name: yojimbo, wwwpart: unclassified }
+
 # MrS0m30n3 abandoned in 2018, oleksis is an active fork
 - { name: youtube-dl-gui, wwwpart: [MrS0m30n3, oleksis, pypi.org/project/youtube-dlg/, pypi.org/project/yt-dlg/, github.com/yt-dlg/yt-dlg, https://yt-dlg.github.io/yt-dlg/], setname: youtube-dl-gui-wxpython }
 # jely2002 abandoned in 2022, StefanLobbenmeier is an active fork


### PR DESCRIPTION
Since yojimbo-organizer from barebones is a macOS-only package, I'm not sure if using the split rules is appropriate.