### PR TITLE
json-spirit: merge

### DIFF
--- a/800.renames-and-merges/j.yaml
+++ b/800.renames-and-merges/j.yaml
@@ -81,6 +81,7 @@
 - { setname: json-c,                   name: [json-c12,json-c0.12,libjson0,libjson-c] }
 - { setname: json-c,                   name: emscripten-json-c, addflavor: emscripten }
 - { setname: json-glib,                name: [libjson-glib,json-glib1.0] }
+- { setname: json-spirit,              name: libjson-spirit }
 - { setname: jsoncpp,                  name: libjsoncpp }
 - { setname: jsonrpc-glib,             name: libjsonrpc-glib }
 - { setname: jss,                      name: mozilla-jss }


### PR DESCRIPTION
Merging https://repology.org/project/json-spirit/related

- `json-spirit` is a C++ JSON parser/generator
- `libjson-spirit` references the library and other developer files of the former, and its only entry links to the appropriate homepage

After some time searching, it seems as if the homepage of both packages are the same, but it appears invalid as upstream changed their URL schema; in other words, the homepage changed ([it still works](https://www.codeproject.com/articles/JSON-Spirit-A-C-JSON-Parser-Generator-Implemented#comments-section), might error out but reloading it should make it appear) 

`json-spirit` == `libjson-spirit`, thus they should be merged.