### PR TITLE
mongo-tools: rename from mongodb-tools, extend

### DIFF
--- a/800.renames-and-merges/m.yaml
+++ b/800.renames-and-merges/m.yaml
@@ -327,10 +327,10 @@
 - { setname: mongo-c-driver,           name: libbson, addflavor: true } # moved into, see https://github.com/mongodb/libbson
 - { setname: mongo-c-driver,           name: [libmongoc,mongoc] }
 - { setname: mongo-cxx-driver,         name: [$0-legacy, mongocxx] }
+- { setname: mongo-tools,              name: [mongodb-tools, mongodb-database-tools] }
 - { setname: mongodb,                  namepat: "mongo(db)?[0-9.-]+" }
 - { setname: mongodb,                  namepat: "mongodb-bin-[0-9.-]+", addflavor: bin }
 - { setname: mongodb,                  name: mongodb-beta, weak_devel: true, nolegacy: true }
-- { setname: mongodb-tools,            namepat: "mongodb[0-9.-]+-tools" }
 - { setname: mongoose,                 name: libmongoose } # split in 850
 - { setname: mongoose,                 name: mongoose-server } # split in 850
 - { setname: mono-flickrnet,           name: flickrnet-bin, addflavor: true }


### PR DESCRIPTION
- Rename project set from mongodb-tools to mongo-tools
- Add missing variants: mongodb-tools, -bin, -git and -dbginfo


rename as mongo-tools is used for most repos
https://repology.org/project/mongo-tools/versions
https://repology.org/project/mongodb-tools/versions