### PR TITLE
trilium: Merge trilium, trilium-next, triliumnext

### DIFF
--- a/800.renames-and-merges/t.yaml
+++ b/800.renames-and-merges/t.yaml
@@ -267,8 +267,9 @@
 - { setname: tridactyl-native,         name: firefox-tridactyl-native }
 - { setname: trigger-rally,            name: trigger }
 - { setname: trigger-rally,            name: [trigger-data, trigger-rally-data], addflavor: data }
-- { setname: trilium,                  name: [trilium-desktop, trilium-notes] }
-- { setname: triliumnext,              name: [trilium-next-desktop, trilium-next-server], addflavor: true }
+- { setname: trilium,                  name: [trilium-desktop, trilium-next-desktop], addflavor: desktop }
+- { setname: trilium,                  name: [trilium-server, trilium-next-server], addflavor: server }
+- { setname: trilium,                  name: [trilium-notes, trilium-next, triliumnext] }
 - { setname: trippy,                   name: rust:$0 }
 - { setname: tripwire,                 name: [tripwire-131,tripwire12] }
 - { setname: trn,                      name: trn4 }


### PR DESCRIPTION
[TriliumNext is the continuation from Trilium, and is accepted by the original creator](https://github.com/TriliumNext/Trilium?tab=readme-ov-file#why-triliumnext). The [original "non-next" repo](https://github.com/zadam/trilium) redirects to the [current "next" repo](https://github.com/TriliumNext/Trilium). The "-next" name is seldom used except for disambiguation.

Feel free to edit PR if needed.