### PR TITLE
Add signal-tlsd rules

### DIFF
--- a/800.renames-and-merges/s.yaml
+++ b/800.renames-and-merges/s.yaml
@@ -178,6 +178,7 @@
 - { setname: sidplay,                  name: sidplay-base, addflavor: true }
 - { setname: sieve,                    name: [sieve-app, sieve-editor-gui, thunderbird-sieve] }
 - { setname: signal-desktop,           name: signal-desktop-beta, weak_devel: true, nolegacy: true }
+- { setname: signal-tlsd,              name: rust:$0 }
 - { setname: signond,                  name: signon } # XXX: problem
 - { setname: signond,                  name: [signon-qt5, signon-qt6], addflavor: true } # XXX: problem
 - { setname: signond,                  name: signond-qt6, addflavor: true }


### PR DESCRIPTION
Standard rule to match Debian Rust package with non-Debian pkgs:
- https://repology.org/project/rust%3Asignal-tlsd/versions
- https://repology.org/project/signal-tlsd/versions