### PR TITLE
cachefetch: add `-bin` suffix

### DIFF
--- a/800.renames-and-merges/c.yaml
+++ b/800.renames-and-merges/c.yaml
@@ -17,7 +17,7 @@
 - { setname: cabal-plan,               name: haskell:$0 }
 - { setname: cabal2nix,                name: haskell:$0 }
 - { setname: cabin,                    name: cabinpkg }
-- { setname: cachefetch,               name: rust:$0 }
+- { setname: cachefetch,               name: [rust:$0, $0-bin], addflavor: true }
 - { setname: cachix,                   name: haskell:$0 }
 - { setname: cacti-spine,              name: cacti-cactid } # cactid renamed to spine upstream
 - { setname: caddy,                    name: [$0-full,$0-with-cgi,$0-no-telemetry,$0-with-quic,$0-bin,$0-cloudflare,$0-cloudflare-l4,$0-desec,$0-dnspod,$0-he,$0-hetzner,$0-l4,$0-multiplugins,$0-naiveproxy,$0-naiveproxy-trojan,$0-trojan], addflavor: true }


### PR DESCRIPTION
Adds `-bin` suffix to `cachefetch`s name list. And adds `addflavor: true` setting.