### PR TITLE
nono: split

### DIFF
--- a/850.split-ambiguities/n.yaml
+++ b/850.split-ambiguities/n.yaml
@@ -117,6 +117,10 @@
 - { name: nomad, wwwpart: savannah, setname: nomad-browser }
 - { name: nomad, addflag: unclassified }
 
+- { name: nono, wwwpart: isaki, setname: nono-emulator }
+- { name: nono, wwwpart: always-further, setname: nono-sandbox }
+- { name: nono, addflag: unclassified }
+
 - { name: nonpareil, wwwpart: brouhaha, setname: nonpareil-calculator-simulator }
 - { name: nonpareil, wwwpart: enve-omics, setname: nonpareil-metagenomic-coverage }
 - { name: nonpareil, addflag: unclassified }


### PR DESCRIPTION
Hello Dmitry

Thanks for creating and maintaining a fantastic resource.

I've attempted to follow the guidance in the [README.md](https://github.com/repology/repology-rules#you-want-to-split-different-projects-with-the-same-name)
and split the two `nono` projects into `nono-emulator` and `nono-sandbox`.

Links:
* https://repology.org/project/nono/versions
* https://www.pastel-flower.jp/~isaki/nono/
* https://github.com/always-further/nono

Please let me know if I've made any mistakes.
