### PR TITLE
pelican: split

### DIFF
--- a/850.split-ambiguities/p.yaml
+++ b/850.split-ambiguities/p.yaml
@@ -141,6 +141,10 @@
 # also abandonware network utility
 - { name: peep, addflag: unclassified }
 
+- { name: pelican, wwwpart: pelicanplatform, setname: $0-federation }
+- { name: pelican, wwwpart: [getpelican,pypi/pelican], setname: $0-static-generator }
+- { name: pelican, addflag: unclassified }
+
 - { name: perl, wwwpart: strawberry, setname: strawberryperl }
 
 - { name: perseus, wwwpart: framesurge, setname: rust:perseus }


### PR DESCRIPTION
I noticed that the Spack [pelican](https://repology.org/project/pelican/versions) package leads to a different repo (https://github.com/PelicanPlatform/pelican) than all of the other packages (https://github.com/getpelican/pelican), making all of the other ones look out of date.

I think this should address that - if you want me to change anything, feel free to let me know! Thank you!