### PR TITLE
nix: prefix home-assistant-custom-components with python:

### DIFF
--- a/500.wildcard.yaml
+++ b/500.wildcard.yaml
@@ -255,6 +255,7 @@
 - { setname: "python:$2", addflag: wconce, noflag: [wconce,not_wildcard,not_python], namepat: "python([23])?-(.*)", ruleset: [slackbuilds], addflavor: $1 }
 - { setname: "python:$2", addflag: wconce, noflag: [wconce,not_wildcard,not_python], namepat: "python([0-9]\\.[0-9]{1,2})-(.*)", ruleset: nix, addflavor: $1 } # TODO: limit with nix_no_name after transition
 - { setname: "python:$0", addflag: wconce, noflag: [wconce,not_wildcard,not_python], categorypat: "python[0-9]+Packages", ruleset: nix_name } # TODO: flavor from category
+- { setname: "python:$1", addflag: wconce, noflag: [wconce,not_wildcard,not_python], namepat: "[^-]+-(.*)", category: home-assistant-custom-components, ruleset: [nix_name, nix_no_name] }
 - { setname: "python:$1", addflag: wconce, noflag: [wconce,not_wildcard,not_python], namepat: "py[23]?-(.*)", ruleset: [alpine,adelie] }
 - { setname: "python:$1", addflag: wconce, noflag: [wconce,not_wildcard,not_python], namepat: "py[0-9]*-(.*)", ruleset: macports }
 - { setname: "python:$1", addflag: wconce, noflag: [wconce,not_wildcard,not_python], namepat: "python[23]?-(.*)", ruleset: kaos }


### PR DESCRIPTION
also strips github usernames from project names

verification:
nix_no_name: josephabbey-calendar-export  ->  python:calendar-export
nix_name: python:blakeblackshear-frigate  -> python:frigate