### PR TITLE
cargo-feature-combinations: merge

### DIFF
--- a/800.renames-and-merges/c.yaml
+++ b/800.renames-and-merges/c.yaml
@@ -91,6 +91,7 @@
 - { setname: cargo-duplicates,         name: rust:$0 }
 - { setname: cargo-edit,               name: rust:$0 }
 - { setname: cargo-expand,             name: rust:$0 }
+- { setname: cargo-feature-combinations,name: rust:$0 }
 - { setname: cargo-flamegraph,         name: rust:$0 }
 - { setname: cargo-fuzz,               name: rust:$0 }
 - { setname: cargo-geiger,             name: rust:$0 }


### PR DESCRIPTION
`cargo-feature-combinations` [have been added to nixpkgs](https://github.com/NixOS/nixpkgs/pull/518134) and is already [available on crates.io](https://crates.io/crates/cargo-feature-combinations)

the name is really long, should i add a space before every `name` of the file to align them ?