### PR TITLE
python-rclone: merge into python:rclone-python

### DIFF
--- a/800.renames-and-merges/python:.yaml
+++ b/800.renames-and-merges/python:.yaml
@@ -344,6 +344,7 @@
 - { setname: python:quart,             name: quart } # vulnerable
 - { setname: python:rabbyt,            name: rabbyt }
 - { setname: python:rawkit,            name: rawkit }
+- { setname: python:rclone-python,     name: python-rclone }
 - { setname: python:rdflib,            name: rdflib }
 - { setname: python:readlike,          name: readlike }
 - { setname: python:redis,             name: [python:redis-py,redis-py] }


### PR DESCRIPTION
The [AUR package](https://aur.archlinux.org/packages/python-rclone) is for [rclone-pyhton](https://github.com/Johannes11833/rclone_python) as it has described in `provides` section.