### PR TITLE
caddy: fix composite AUR versions (e.g. from caddy-cloudflare-l4)

### DIFF
--- a/900.version-fixes/c.yaml
+++ b/900.version-fixes/c.yaml
@@ -9,6 +9,7 @@
 - { name: c2man,                       verpat: "2\\.[0-9]{2,}",                            incorrect: true, disposable: true } # hpux, it's 2.0.4X
 - { name: ca-certificates-mozilla,     verpat: "20[0-9]{2}.*",                             incorrect: true }
 - { name: caddy,                       verpat: "[^0-9].*",                                 incorrect: true } # "caddy2" "beta10" - "2" is part of the version
+- { name: caddy,                       ruleset: aur, verpat: "([0-9]+\\.[0-9]+\\.[0-9]+)\\..*", setver: $1 }
 - { name: cadence,                     verlonger: 3,                 ruleset: freebsd,     incorrect: true }
 - { name: cadical,                     ver: "06w",                                         sink: true }
 - { name: caffe,                       verpat: ".*20[0-9]{6}.*",                           snapshot: true }


### PR DESCRIPTION
**This PR was made by Gemini via Antigravity, I apologize in advance if it's garbage.** 

The AUR package caddy-cloudflare-l4 uses a composite versioning scheme (e.g. 2.11.3.0.2.4.0.1.1) which appends the versions of the plugins to the main caddy version. Since this package is renamed/merged into caddy, it causes Repology to detect 2.11.3.0.2.4.0.1.1 as the latest version of Caddy.

This rule trims the composite AUR versions to the core caddy version (first 3 components).
