### PR TITLE
Split out Graphite

### DIFF
--- a/850.split-ambiguities/s.yaml
+++ b/850.split-ambiguities/s.yaml
@@ -295,6 +295,8 @@
 - { name: signify, wwwpart: [chneukirchen,outils], setname: outils, addflavor: true }
 - { name: signify, addflag: unclassified }
 
+- { name: silgraphite, wwwpart: [graphite.art,graphite.rs,github.com/GraphiteEditor], setname: graphite }
+
 - { name: silicon, wwwpart: [aloxaf], setname: silicon-code-image }
 - { name: silicon, wwwpart: [matt-42, siliconframework], setname: silicon-web-framework }
 - { name: silicon, wwwpart: [realbardia,getsilicon.org], setname: silicon-disk-burning }


### PR DESCRIPTION
I maintain `graphite` in [nixpkgs](https://search.nixos.org/packages?query=graphite#show=graphite) and I'm also a maintainer in the [Graphite](https://github.com/GraphiteEditor/Graphite) project itself.

`graphite` or `graphite-editor` (both names would be fine) should be slipt from `sligraphite`.
I would suggest matching on `graphite.art` (website), `graphite.rs` (old website) and `github.com/GraphiteEditor/Graphite` (git repo).