### PR TITLE
fix: Handle js-beautify collision by renaming projects

### DIFF
--- a/repology/repology-rules/rules.py
+++ b/repology/repology-rules/rules.py
@@ -1,0 +1,24 @@
+import re
+
+# ... existing code ...
+
+# Add a new rule to handle the js-beautify collision
+rules.append(
+    {
+        'name': 'js-beautify',
+        'match': re.compile(r'^js-beautify$'),
+        'replace': 'js-beautify-js',
+        'comment': 'Rename js-beautify to js-beautify-js to avoid collision with jsbeautifier',
+    }
+)
+
+rules.append(
+    {
+        'name': 'jsbeautifier',
+        'match': re.compile(r'^jsbeautifier$'),
+        'replace': 'js-beautify-py',
+        'comment': 'Rename jsbeautifier to js-beautify-py to avoid collision with js-beautify',
+    }
+)
+
+# ... existing code ...


### PR DESCRIPTION
## Problem
The js-beautify project is colliding with the jsbeautifier project, causing unexpected behavior.

## Solution
Added new rules to handle the js-beautify collision by renaming the projects.

## Testing
Run the existing test suite to ensure the changes do not break any existing functionality.

---
*Closes #989*

> 🤖 Generated by AutoGit