### PR TITLE
tewi: rename python package to tewi-torrent

### DIFF
--- a/800.renames-and-merges/t.yaml
+++ b/800.renames-and-merges/t.yaml
@@ -110,7 +110,7 @@
 - { setname: tetrinetx,                name: [tetrinet-x,tetrinet-server] }
 - { setname: tevent,                   name: [libtevent,tevent1] }
 - { setname: tevent,                   name: tevent-man, addflavor: man }
-- { setname: tewi,                     name: python:tewi-transmission }
+- { setname: tewi,                     name: python:tewi-torrent }
 - { setname: tex-fmt,                  name: "rust:tex-fmt" }
 - { setname: texinfo,                  name: [texinfo4, gtexinfo] }
 - { setname: texinfo,                  name: info-reader, addflavor: true }

--- a/800.renames-and-merges/t.yaml
+++ b/800.renames-and-merges/t.yaml
@@ -110,7 +110,7 @@
 - { setname: tetrinetx,                name: [tetrinet-x,tetrinet-server] }
 - { setname: tevent,                   name: [libtevent,tevent1] }
 - { setname: tevent,                   name: tevent-man, addflavor: man }
-- { setname: tewi,                     name: python:tewi-torrent }
+- { setname: tewi,                     name: [python:tewi-torrent, python:tewi-transmission] }
 - { setname: tex-fmt,                  name: "rust:tex-fmt" }
 - { setname: texinfo,                  name: [texinfo4, gtexinfo] }
 - { setname: texinfo,                  name: info-reader, addflavor: true }


### PR DESCRIPTION
PyPI package was renamed from `tewi-transmission` to `tewi-torrent`, new versions released only to `tewi-torrent`.

Not sure about Repology rules, maybe `tewi` entry should contain both of them?