### PR TITLE
Move rocr-runtime verpat to new set_rocm.

### DIFF
--- a/880.project-sets.yaml
+++ b/880.project-sets.yaml
@@ -405,3 +405,14 @@
     - umbrello
     - yakuake
     - zanshin
+
+- addflag: set_rocm
+  name:
+    - half-rocm
+    - rocm-cmake
+    - rocm-core
+    - rocm-device-libs
+    - rocm-llvm
+    - rocm-runtime
+    - rocm-smi-lib
+    - rocminfo

--- a/900.version-fixes/r.yaml
+++ b/900.version-fixes/r.yaml
@@ -140,7 +140,6 @@
 - { name: robotfindskitten,            verpat: "20[0-9]{2}.*",                             incorrect: true } # termux
 - { name: rocksndiamonds-data,                                                             noscheme: true } # usually a bunch of versionless level sets
 - { name: rocm-device-libs,            verge: "15",                                        incorrect: true } # fedora, uses llvm version
-- { name: rocr-runtime,                verpat: "[0-9]+\\.[0-9]+",                          incorrect: true } # therock-7.13 vs. rocm-7.2.4 tags. assuming the former unrelated
 - { name: rocs,                        verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
 - { name: rofi-wayland,                verpat: ".*wayland.*",                              any_is_patch: true }
 - { name: rpcgen,                                                    ruleset: ravenports,  ignore: true } # fake

--- a/901.version-fixes.sets.yaml
+++ b/901.version-fixes.sets.yaml
@@ -10,3 +10,4 @@
 - { flag: set_kdeplasma,               verpat: "[12][0-9]\\..*",                           sink: true } # services moved to plasma such as print-manager
 - { flag: set_kdeplasma,               verlt: "6",                                         sink: true }
 - { flag: set_kdeplasma,                                             ruleset: fedora,      untrusted: true } # accused of faking versions for frameworks and gears
+- { flag: set_rocm,                    verpat: "[0-9]+\\.[0-9]+",                          incorrect: true } # therock-7.13 vs. rocm-7.2.4 tags. assuming the former unrelated


### PR DESCRIPTION
Fix more experimental "the-rock" tech preview versions.