### PR TITLE
fetchit: split

### DIFF
--- a/850.split-ambiguities/f.yaml
+++ b/850.split-ambiguities/f.yaml
@@ -61,6 +61,11 @@
 - { name: fetch, sourceforge: fetch, setname: fetch-lhanson }
 - { name: fetch, addflag: unclassified }
 
+- { name: fetchit, wwwpart: [fetchit.readthedocs.io, containers], setname: fetchit-containers}
+- { name: fetchit, wwwpart: nzuum, setname: fetchit-sysinfo-nzuum }
+- { name: fetchit, wwwpart: ruturajn, setname: fetchit-sysinfo-ruturajn }
+- { name: fetchit, addflag: unclassified }
+
 - { name: fex, wwwpart: [semicomplete,jordansissel], setname: fex-field-extraction }
 - { name: fex, wwwpart: [uni-stuttgart,belwue], setname: fex-file-exchange }
 - { name: fex, wwwpart: fex-emu, setname: fex-emu }


### PR DESCRIPTION
Splitting https://repology.org/project/fetchit/versions

- https://github.com/Ruturajn/fetchit is a fetch tool similar to neofetch written in Rust, advertised as supporting Linux only
- https://codeberg.org/nzuum/fetchit is a fastfetch alternative written in C
- https://github.com/containers/fetchit is tool to manage the life cycle and configuration of Podman containers, written in Go

These packages have been split into the following, respectively

- `fetchit-ruturajn`
- `fetchit-nzuum`
- `fetchit-containers`

Not all 3 serve the same purpose, with each maintaining different project structures (Rust vs. C vs. Golang), Thus, they should be split into different entries.