### PR TITLE
Add version pattern for 'ns' in n.yaml

### DIFF
--- a/900.version-fixes/n.yaml
+++ b/900.version-fixes/n.yaml
@@ -152,6 +152,7 @@
 - { name: nrg2iso,                     ver: "0.5",                   ruleset: opensuse,    incorrect: true }
 - { name: nrg2iso,                                                   ruleset: opensuse,    untrusted: true } # accused of fake 0.5
 - { name: nrsc5,                       verpat: ".+20[0-9]{6}",                             snapshot: true }
+- { name: ns,                          verpat: "([0-9]{2,})",        ruleset: nix,         setver: "3.$1" } # nixpkgs sets ns-3 version to bare minor, e.g. 47 -> ns-3.47
 - { name: nss-ldap,                    verpat: "1\\.([0-9]{3,})",                          setver: "$1" } # FreeBSD garbage
 - { name: ntfs-3g,                     verpat: ".*ar.*",                                   any_is_patch: true, devel: true } # http://jp-andre.pagesperso-orange.fr/advanced-ntfs-3g.html
 - { name: ntfs-3g,                     verpat: "[0-9]+(\\.[0-9]+){3}",                     incorrect: true } # incorrect scheme for ARs


### PR DESCRIPTION
nixpkgs sets ns-3 version to bare minor, e.g. 47 -> ns-3.47