### PR TITLE
suck: merge

### DIFF
--- a/800.renames-and-merges/s.yaml
+++ b/800.renames-and-merges/s.yaml
@@ -453,6 +453,7 @@
 - { setname: sublime-text,             name: [sublime-text-3-imfix,sublime-text-imfix], addflavor: imfix }
 - { setname: sublime-text,             name: [sublime-text-4-dev, sublime-text-dev, sublime-text-nightly], weak_devel: true, nolegacy: true }
 - { setname: sublime-text,             namepat: "sublime-?text[0-9.-]*" }
+- { setname: suck,                     name: suck-cnews }
 - { setname: sudo,                     name: [sudo-pam,sudo-masochist,sudo-selinux], addflavor: true }
 - { setname: sugar,                    namepat: "sugar[0-9.-]+" }
 - { setname: sugar-activity,           namepat: "sugar-activity[0-9.-]+" }


### PR DESCRIPTION
Merging https://repology.org/project/suck/related

- `suck` is a program used to grab news from a remote NNTP news server
- `suck-cnews` is the same program, pointing to the same upstream, that uses the [C News](https://www.dinoex.net/software.html) news distributor in order to handle news servers

`suck` == `suck-cnews`, given that they point to the same upstream. Thus, they should be merged.