### PR TITLE
muon-meson: merge

### DIFF
--- a/800.renames-and-merges/m.yaml
+++ b/800.renames-and-merges/m.yaml
@@ -436,6 +436,7 @@
 - { setname: munin,                    name: [$0-master, $0-node, $0-server, $0-common], addflavor: true }
 - { setname: munin,                    name: munin-hashchecker } # different project tha munin-monitoring, split in 850
 - { setname: munt,                     name: [munt-alsadrv, munt-mt32emu-alsadrv], addflavor: alsadrv }
+- { setname: muon-meson,               name: [muon-as-meson-wrapper, muon-embedded-samurai]}
 - { setname: muparser,                 namepat: "libmuparser[0-9.-]*" }
 - { setname: mupdf,                    name: [libmupdf,mupdf-nojs,mupdf-seccomp,mupdf-tools], addflavor: true }
 - { setname: musepack,                 name: [musepack-tools,libmusepack], addflavor: true }


### PR DESCRIPTION
Merging https://repology.org/project/muon-meson/related

- https://muon.build/ is an implementation of the Meson build system in C99, which has been named `muon-meson` in Repology through [a split](https://github.com/repology/repology-rules/commit/9125d67282c9bd24c67e918e3b9f0b39ae9f3691).

- `muon-as-meson-wrapper` is the name for the same package in the GNU Guix distribution, pointing to the same project upstream as previously mentioned. Its name refers to Guix providing the option to use `muon-meson` as a direct replacement to the Meson build system (through a symlink).

- `muon-embedded-samurai` is the name of various packages in nixpkgs, with the `-embedded-samurai` portion referring to [`samurai`](https://github.com/michaelforney/samurai), an implementation of the Ninja build system in C. These packages all refer to the same upstream as above.

`muon-meson` == (`muon-as-meson-wrapper` AND `muon-embedded-samurai`). Thus, they should be merged.