### PR TITLE
goose: extend split

### DIFF
--- a/850.split-ambiguities/g.yaml
+++ b/850.split-ambiguities/g.yaml
@@ -257,7 +257,7 @@
 - { name: gonvert, ruleset: maemo, setname: gonvert-maemo }
 
 - { name: goose, wwwpart: pressly, setname: $0-database-migration }
-- { name: goose, wwwpart: [aaif-goose,goose-docs.ai], setname: $0-ai-agent }
+- { name: goose, wwwpart: [aaif-goose,block/goose,goose-docs.ai], setname: $0-ai-agent }
 - { name: goose, addflag: unclassified }
 
 - { name: gopass, wwwpart: [gopasspw,gopass.pw], setname: gopass-gopasspw }


### PR DESCRIPTION
Some Goose packages still reference the project’s previous GitHub URL:

https://github.com/block/goose

That URL redirects to its new location:

https://github.com/aaif-goose/goose

Packages using the previous URL are currently classified as
`goose-unclassified`. This extends the existing split rule to recognize
`block/goose` and classify those packages as `goose-ai-agent`.