### PR TITLE
raptor: extend split

### DIFF
--- a/850.split-ambiguities/r.yaml
+++ b/850.split-ambiguities/r.yaml
@@ -34,7 +34,7 @@
 - { name: raphael, wwwpart: DmitryBaranovskiy, setname: js:raphael }
 - { name: raphael, addflag: unclassified }
 
-- { name: raptor, wwwpart: [https://librdf.org/raptor/,dajobe], setname: $0-rdf }
+- { name: raptor, wwwpart: [librdf.org/raptor,dajobe], setname: $0-rdf }
 - { name: raptor, wwwpart: seqan, setname: $0-seqan }
 - { name: raptor, wwwpart: skynettx, setname: $0-game }
 - { name: raptor, addflag: unclassified }


### PR DESCRIPTION
Raptor RDF packages use several variants of the upstream homepage, including:

- `http://librdf.org/raptor/`
- `https://www.librdf.org/raptor`
- `https://librdf.org/raptor`

The existing split rule only matches the scheme-specific `https://librdf.org/raptor/` form, leaving the other variants under `raptor-unclassified`.

Broaden the match to `librdf.org/raptor` so these URL variants are classified as `raptor-rdf`. The existing SeqAn and game classifications remain separate.

Validation: `make check` passes across all 243 YAML files.