### PR TITLE
exo: extend split

### DIFF
--- a/800.renames-and-merges/e.yaml
+++ b/800.renames-and-merges/e.yaml
@@ -200,7 +200,6 @@
 - { setname: exim,                     name: [exim-doc, exim-doc-html, exim-doc-pdf, exim-doc-postscript, eximdoc4, exim-html], addflavor: true }
 - { setname: exim,                     name: [exim-gnutls, exim-heavy, exim-monitor, exim-mysql, exim-postgresql, exim-ldap2, exim-sqlite, exim-sa-exim], addflavor: true }
 - { setname: exiv2,                    namepat: "compat-exiv2-[0-9]+" }
-- { setname: exo,                      name: [libexo, xfce4-exo] }
 - { setname: exo,                      name: exo-devel, weak_devel: true, nolegacy: true }
 - { setname: exo,                      name: exo-gtk3, addflavor: true }
 - { setname: exoscale-cli,             name: exoscale }

--- a/800.renames-and-merges/x.yaml
+++ b/800.renames-and-merges/x.yaml
@@ -68,6 +68,7 @@
 - { setname: xerces-j,                 name: xerces, ruleset: gentoo, category: dev-java }
 - { setname: xerces-j,                 namepat: "(?:lib)?xerces2?-?j(?:ava)?[0-9-]*" }
 - { setname: xerces-j,                 name: [java-xerces,"java:xerces2"] }
+- { setname: xfce-exo,                 name: [libexo,xfce4-exo] }
 - { setname: xfce4-dict,               name: xfce4-dict-plugin, ruleset: freebsd }
 - { setname: xfce4-whiskermenu-plugin, name: [xfce4-panel-plugin-whiskermenu] }
 - { setname: xfce4-whiskermenu-plugin, name: [xfce4-whiskermenu-plugin-gtk2,xfce4-whiskermenu-plugin-gtk3], addflavor: true }

--- a/850.split-ambiguities/e.yaml
+++ b/850.split-ambiguities/e.yaml
@@ -213,9 +213,9 @@
 - { name: eval, wwwpart: mblab, setname: eval-gene-structure-prediction }
 - { name: eval, addflag: unclassified }
 
-- { name: exo, wwwpart: ndiscover.com/family/exo, setname: fonts:$0 }
-- { name: exo, wwwpart: exo-explore, setname: $0-ai }
-- { name: exo, wwwpart: xfce.org/xfce/exo, setname: xfce-$0 }
+- { name: exo, wwwpart: [ndiscover.com/family/exo,ndiscovered.com,ndiscover.com/exo-2-0], setname: fonts:$0 }
+- { name: exo, wwwpart: [exo-explore,exolabs.net], setname: $0-ai }
+- { name: exo, wwwpart: xfce.org, setname: xfce-$0 }
 - { name: exo, addflag: unclassified }
 
 - { name: express, wwwpart: bio.math.berkeley.edu, setname: express-rna-seq }


### PR DESCRIPTION
`exo-unclassified` contains packages from multiple unrelated projects whose current homepage URLs are not covered by the existing split rules.

This change:

- maps the unambiguous `libexo` and `xfce4-exo` package names directly to `xfce-exo`;
- broadens the Xfce URL match to `xfce.org`;
- adds `exolabs.net` for the distributed AI runtime;
- adds the current `ndiscovered.com` and `ndiscover.com/exo-2-0` URLs for the Exo font.

The existing catch-all remains for packages without enough identifying metadata.

Validation: `make check` passes across all 243 YAML files.