### PR TITLE
mac: extend split

### DIFF
--- a/850.split-ambiguities/m.yaml
+++ b/850.split-ambiguities/m.yaml
@@ -1,6 +1,6 @@
 # vim: tabstop=29 expandtab softtabstop=29 nomodeline
 
-- { name: mac, wwwpart: monkeysaudio.com, setname: monkeys-audio }
+- { name: mac, wwwpart: [monkeysaudio.com,monkeys-audio,mac-port,supermmx], setname: monkeys-audio }
 - { name: mac, addflag: unclassified }
 
 - { name: maddy, wwwpart: [foxcpp,maddy.email], setname: maddy-mail-server }


### PR DESCRIPTION
Classify additional Monkey's Audio packages named `mac` using project-specific homepage and source URL identifiers.

This extends the existing `monkeysaudio.com` match with `monkeys-audio`, `mac-port`, and `supermmx`, while leaving unrelated packages named `mac` unclassified.