### PR TITLE
fusefs:hfsfuse: merge

### DIFF
--- a/800.renames-and-merges/fusefs:.yaml
+++ b/800.renames-and-merges/fusefs:.yaml
@@ -12,6 +12,7 @@
 - { setname: "fusefs:gitfs",           name: gitfs }
 - { setname: "fusefs:gphotofs",        name: gphotofs }
 - { setname: "fusefs:gphotofs",        name: gphoto2fs } # nix, XXX: problem
+- { setname: "fusefs:hfsfuse",         name: hfsfuse }
 - { setname: "fusefs:httpdirfs",       name: [httpdirfs,httpdirfs-fuse] }
 - { setname: "fusefs:ifuse",           name: ifuse }
 - { setname: "fusefs:jmtpfs",          name: jmtpfs }


### PR DESCRIPTION
Merging https://repology.org/project/hfsfuse/related

- [hfsfuse](https://github.com/0x09/hfsfuse) is a FUSE driver for HFS+ filesystems
- `fusefs:*` is the convention for FUSE related project in Repology (e.g `ifuse` -> `fusefs:ifuse`)
- `fusefs:hfsfuse` contains an entry by FreeBSD which points to the same upstream as `hfsfuse`.

`hfsfuse` == `fusefs:hfsfuse`. Thus, they should be merged.