### PR TITLE
discount: merge

### DIFF
--- a/800.renames-and-merges/d.yaml
+++ b/800.renames-and-merges/d.yaml
@@ -122,6 +122,7 @@
 - { setname: discordchatexporter,      name: [discordchatexporter-cli, discord-chat-exporter-cli], addflavor: cli }
 - { setname: discordchatexporter,      name: [discordchatexporter-desktop], addflavor: desktop }
 - { setname: discordchatexporter,      name: discord-chat-exporter }
+- { setname: discount,                 name: [discount2, libmarkdown2] }
 - { setname: discover,                 name: discover-snap, addflavor: snap }
 - { setname: discover,                 name: discover-git, weak_devel: true, nolegacy: true }
 - { setname: discover-overlay,         name: "python:discover-overlay" }


### PR DESCRIPTION
Merging https://repology.org/project/discount/related

- discount is a Markdown to HTML tool written in C, hosted at https://github.com/Orc/discount and https://www.pell.portland.or.us/~orc/Code/discount/.
- `libmarkdown2` provides the library which the `discount` project offers, and refers to the latter upstream
- `discount2` provides the binaries for an older version of the `discount` projects, and refers to the latter upstream

`discount` == (`libmarkdown2` AND `discount2`). Additionally, both upstreams linked are valid homepages, since they refer to the same project. Thus, they should be merged.