### PR TITLE
hadolint: merge

### DIFF
--- a/800.renames-and-merges/h.yaml
+++ b/800.renames-and-merges/h.yaml
@@ -7,6 +7,7 @@
 - { setname: hackrf,                   name: [hackrf-tools, hackrf-host], addflavor: true }
 - { setname: haconiwa,                 name: python:$0 }
 - { setname: hadolint,                 name: "haskell:$0" }
+- { setname: hadolint,                 name: $0-bin, addflavor: true }
 - { setname: hadoop,                   name: hadoop2 }
 - { setname: haiti,                    name: ["ruby:haiti-hash", haiti-hash] }
 - { setname: half,                     name: rocm-half }


### PR DESCRIPTION
Merging https://repology.org/project/hadolint/related

- hadolint is a Dockerfile linter to validate "best practices", whose upstream is https://github.com/hadolint/hadolint.
- `hadolint-bin` is the name of the same project under SlackerBuilds, and points to the same upstream and homepage as the former
- `hadolint-bin` also exists in the AUR, so there is precedent

`hadolint` == `hadolint-bin`. Thus, they should be merged.