### PR TITLE
alot: merge

### DIFF
--- a/800.renames-and-merges/a.yaml
+++ b/800.renames-and-merges/a.yaml
@@ -175,6 +175,7 @@
 - { setname: allureofthestars,         name: "haskell:allure" }
 - { setname: alog,                     name: lib$0 }
 - { setname: alogg,                    name: [liballegroogg,allegroogg] }
+- { setname: alot,                     name: "python:$0" }
 - { setname: alpaca,                   name: alpaca-ai } # split in 850
 - { setname: alpine,                   name: alpine-fancythreading, addflavor: true }
 - { setname: alsa-lib,                 name: alsa-lib-devel, weak_devel: true, nolegacy: true }


### PR DESCRIPTION
Merging https://repology.org/project/python:alot/related

- `python:alot` is the appropriate name for https://github.com/pazz/alot
- `alot` maintains most packages which point directly to the same upstream as the former; same homepage

`python:alot` == `alot`. Thus, they should be merged accurately. 