### PR TITLE
gdown: merge

### DIFF
--- a/800.renames-and-merges/g.yaml
+++ b/800.renames-and-merges/g.yaml
@@ -69,6 +69,7 @@
 - { setname: gdm,                      namepat: "gdm[0-9.-]+" }
 - { setname: gdm,                      name: gdm-old }
 - { setname: gdnsd,                    name: [gdnsd2,gdnsd3] }
+- { setname: gdown,                    name: "python:$0" }
 - { setname: gdtoolkit,                name: [gdtoolkit3,python:$0] }
 - { setname: geant4-data-g4abla,       name: geant4-abladata }
 - { setname: geant4-vmc,               name: geant-vmc }


### PR DESCRIPTION
Merging https://repology.org/project/gdown/related

- `gdown` is a wget/curl-like CLI for Google Drive, hosted at https://github.com/wkentaro/gdown
- `python:gdown` contains entries relating to `gdown`, having the same upstream and homepage; it can be used as a module, per their documentation.

`gdown` == `python:gdown`. Thus, they should be merged.