### PR TITLE
handbrake: merge

### DIFF
--- a/800.renames-and-merges/h.yaml
+++ b/800.renames-and-merges/h.yaml
@@ -13,7 +13,8 @@
 - { setname: half,                     name: rocm-half }
 - { setname: hamachi,                  name: logmein-hamachi }
 - { setname: hamster-time-tracker,     name: hamster-time-tracker-legacy }
-- { setname: handbrake,                name: [handbrake-cli,handbrake-fdkaac,handbrakecli,handbrake-full,handbrake-nvenc,handbrake-no-qsv], addflavor: true }
+- { setname: handbrake,                name: [handbrake-cli,handbrakecli,handbrake-full,handbrake-semifull,handbrake-dev,handbrake-gui,handbrake-llvm-optimized,handbrake-svt-av1-hdr], addflavor: true }
+- { setname: handbrake,                name: [handbrake-cli-snapshot, handbrake-snapshot], weak_devel: true, nolegacy: true }
 - { setname: handlr,                   name: [xdg-utils-handlr, handlr-regex, rust:handlr-regex] } # handlr-regex is the alive fork; original project is abandoned
 - { setname: hangups,                  name: "python:hangups" }
 - { setname: haproxy,                  namepat: "haproxy[0-9.-]*" }


### PR DESCRIPTION
Hi

This merge the variants of handbrake https://repology.org/projects/?search=handbrake&maintainer=&category=&inrepo=&notinrepo=&repos=&families=&repos_newest=&families_newest=

On Scoop there are snapshot 

Removed no longer needed variants since it was getting crowded, they were all on AUR and removed between last year and 4 years ago

handbrake-fdkaac
handbrake-nvenc
handbrake-no-qsv

https://lists.archlinux.org/archives/search?q=handbrake&page=1&mlist=aur-requests%40lists.archlinux.org&sort=date-desc