### PR TITLE
markless: split

### DIFF
--- a/850.split-ambiguities/m.yaml
+++ b/850.split-ambiguities/m.yaml
@@ -81,6 +81,10 @@
 - { name: markdownlint, wwwpart: DavidAnson, setname: node:markdownlint }
 - { name: markdownlint, addflag: unclassified }
 
+- { name: markless, wwwpart: jvanderberg, addflag: classified }
+- { name: markless, wwwpart: shirakumo, setname: cl-markless }
+- { name: markless, addflag: unclassified }
+
 - { name: mars, wwwpart: [marsshooter,mars-game], setname: m.a.r.s. }
 - { name: mars, wwwpart: www.mpibpc.mpg.de, setname: mars-proteins-assignment }
 - { name: mars, wwwpart: Sony-PS3/mars, setname: mars-runtime-system }


### PR DESCRIPTION
Separate [shirakumo/cl-markless](https://github.com/shirakumo/cl-markless) (Common Lisp Markless processor, packaged in AUR) from [jvanderberg/markless](https://github.com/jvanderberg/markless) (terminal markdown viewer, packaged in FreeBSD, nixpkgs and AUR), merging the former into the existing cl-markless project.