### PR TITLE
dotconf: merge

### DIFF
--- a/800.renames-and-merges/d.yaml
+++ b/800.renames-and-merges/d.yaml
@@ -184,6 +184,7 @@
 - { setname: dosage,                   name: [gnome-dosage, dosage-tracker, python:dosage] } # different projects, split in 850
 - { setname: dosbox,                   name: [dosbox-sdl2,dosbox-debug,dosbox-multilib-patched,dosbox-ex], addflavor: true }
 - { setname: dosbox,                   name: dosbox-dev }
+- { setname: dotconf,                  name: lib$0 }
 - { setname: dotenv-linter,            name: rust:$0 }
 - { setname: dotnet,                   namepat: "dotnet[0-9.-]+" }
 - { setname: dotnet,                   name: dotnetpreview, weak_devel: true, nolegacy: true }


### PR DESCRIPTION
Merging https://repology.org/project/dotconf/related

- dotconf is a C library for parsing `.conf` files, hosted at https://github.com/williamh/dotconf
- `libdotconf` contains the library files of the same project, and its entries have the same upstream and homepage

`dotconf` == `libdotconf`. Thus, they should be merged.