### PR TITLE
flawfinder: merge

### DIFF
--- a/800.renames-and-merges/f.yaml
+++ b/800.renames-and-merges/f.yaml
@@ -100,6 +100,7 @@
 - { setname: flamelens,                name: rust:$0 }
 - { setname: flare,                    name: [flare-engine,flare-game,flare-data], addflavor: true } # these are actually distinct packages, but too many repos merge them together
 - { setname: flatbuffers,              name: [$0-static, rust:$0, python:$0], addflavor: true }
+- { setname: flawfinder,               name: "python:$0" }
 - { setname: fleet,                    name: fleetctl }
 - { setname: flex,                     name: [compat-flex,flex-old] }
 - { setname: flex,                     name: libflex, addflavor: true }


### PR DESCRIPTION
Merging https://repology.org/project/flawfinder/related

- flawfinder is static analysis tool for finding msitakes which can have potential security risk in C++ code, hosted at https://github.com/david-a-wheeler/flawfinder and homed at https://dwheeler.com/flawfinder/
- `python:flawfinder` contains entries which refer to the afromentioned upstream and homepage

(`flawfinder` == `python:flawfinder`) AND `flawfinder` is not a module. Thus, they should be merged.