### PR TITLE
leaf: update split

### DIFF
--- a/850.split-ambiguities/l.yaml
+++ b/850.split-ambiguities/l.yaml
@@ -20,6 +20,7 @@
 - { name: leaf, wwwpart: eycorsican, setname: leaf-proxy-framework }
 - { name: leaf, wwwpart: IogaMaster, setname: leaf-fetch }
 - { name: leaf, wwwpart: vrongmeal, setname: leaf-reloader }
+- { name: leaf, wwwpart: rivolink, setname: leaf-markdown-viewer }
 - { name: leaf, addflag: unclassified }
 
 - { name: leaflet, wwwpart: [leafletjs,leaflet.cloudmade.com], setname: "js:leaflet" }


### PR DESCRIPTION
Currently, https://leaf.rivolink.mg/ (a markdown file viewer) is identified as unclassified. Merge it into the already existing `leaf-markdown-viewer` project.