### PR TITLE
iris: update split

### DIFF
--- a/850.split-ambiguities/i.yaml
+++ b/850.split-ambiguities/i.yaml
@@ -100,6 +100,7 @@
 - { name: iris, wwwpart: projectiris.co.uk, setname: iris-eye-images }
 - { name: iris, wwwpart: iristech, setname: iris-eye-protection }
 - { name: iris, wwwpart: psi-im, setname: iris-psi }
+- { name: iris, wwwpart: versenilvis, setname: iris-autocomplete }
 - { name: iris, addflag: unclassified }
 
 # see https://github.com/repology/repology-rules/issues/730


### PR DESCRIPTION
Currently, https://github.com/versenilvis/IRIS (a shell auto-completer) is identified as unclassified. Merge it into the already existing `iris-autocomplete` project.