### PR TITLE
uriparser: extend merge

### DIFF
--- a/800.renames-and-merges/u.yaml
+++ b/800.renames-and-merges/u.yaml
@@ -102,6 +102,7 @@
 - { setname: urdfdom,                  name: ros-urdfdom }
 - { setname: urdfdom-headers,          name: ros-urdfdom-headers }
 - { setname: uriparser,                name: [liburiparser,liburiparser1], addflavor: lib }
+- { setname: uriparser,                name: $0-doc, addflavor: doc }
 - { setname: urlwatch,                 name: "python:urlwatch" }
 - { setname: usacloud,                 name: usacloud-core, addflavor: true }
 - { setname: usb.ids,                  name: usbids }


### PR DESCRIPTION
Merging https://repology.org/project/uriparser/related

- `uriparser` is a URI parsing library, hosted at https://github.com/uriparser/uriparser
- `uriparser-doc` refers to entries in repositories which "debianize" or separately distribute components (docs for one package, library files in another, etc), but ultimately refer to the same upstream and homepage

`uriparser-doc` == `uriparser`. Thus, the existing merge rule should be extended.