### PR TITLE
google-chrome: update devel rule to 153

### DIFF
--- a/900.version-fixes/g.yaml
+++ b/900.version-fixes/g.yaml
@@ -302,7 +302,7 @@
 - { name: goocanvasmm,                 verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
 - { name: google-authenticator,        verpat: "20[0-9]{6}.*",                             incorrect: true }
 - { name: google-authenticator-libpam, verpat: "20[0-9]{6}.*",                             incorrect: true }
-- { name: google-chrome,               verge: "147",                                       devel: true, maintenance: true } # latest stable mentioned at https://chromereleases.googleblog.com/, needs update every major stable promotion
+- { name: google-chrome,               verge: "153",                                       devel: true, maintenance: true } # latest stable mentioned at https://chromereleases.googleblog.com/, needs update every major stable promotion
 - { name: googlecl,                    ver: "0.9.15.1",              ruleset: freebsd,     incorrect: true }
 - { name: googlecl,                                                  ruleset: freebsd,     untrusted: true }
 - { name: goom,                        verpat: "2004(.*)",                                 setver: "2k4$1" }


### PR DESCRIPTION
Chrome 152 is now stable (promoted August 25, 2026 as per https://chromereleases.googleblog.com/2026/08/stable-channel-update-for-desktop_0256176589.html). This rule marks version 153 and higher (currently 153 Beta / 154 Dev) as development versions.

This ensures Repology correctly identifies 152 as the latest stable release and more accurately calculates package freshness across repositories.