### PR TITLE
karukan: merge

### DIFF
--- a/800.renames-and-merges/k.yaml
+++ b/800.renames-and-merges/k.yaml
@@ -18,6 +18,7 @@
 - { setname: kapp,                     name: carvel-$0 }
 - { setname: kaptan,                   name: kaptan-qt6 }
 - { setname: karaf,                    name: apache-karaf }
+- { setname: karukan,                  name: fcitx5-karukan } # freebsd
 - { setname: kate,                     name: kate-root, addflavor: true }
 - { setname: kbs2,                     name: rust:$0 }
 - { setname: kcc,                      name: knightos-kcc }


### PR DESCRIPTION
Merging https://repology.org/project/karukan/related

- `karukan` (AUR, openSUSE) and `fcitx5-karukan` (FreeBSD ports, `japanese/fcitx5-karukan`) are the same upstream: https://github.com/togatoga/karukan, a Japanese input method for fcitx5 with a neural kana-kanji conversion engine. All three set that URL as the homepage.
- The FreeBSD port is named after the fcitx5 addon it builds, but there is no separate upstream project. openSUSE also builds the `fcitx5-karukan` binary package from the `karukan` source package.

I maintain the openSUSE package.
