### PR TITLE
cloudflared: merge

### DIFF
--- a/800.renames-and-merges/c.yaml
+++ b/800.renames-and-merges/c.yaml
@@ -305,6 +305,7 @@
 - { setname: cloog-ppl,                name: cloog-ppl-gcc4, addflavor: gcc4 }
 - { setname: cloud-init,               name: "python:cloud-init" }
 - { setname: cloudflare-ddns,          name: python:$0 }
+- { setname: cloudflared,              name: $0-bin, addflavor: bin }
 - { setname: cloudfoundry-cli,         name: [cloudfoundry6-cli, cf-cli] }
 - { setname: cloudfoundry-cli,         name: cf-cli-test, addflavor: test }
 - { setname: clucene,                  name: [clucene09,clucene-core,libclucene,libclucene-core] }


### PR DESCRIPTION
Merging https://repology.org/project/cloudflared/related

- cloudflared s the official Cloudflare tunnel utility, hosted at https://github.com/cloudflare/cloudflared
- `cloudflared-bin` is the name of the same project under SlackerBuilds, and points to the same upstream and homepage as the former

`cloudflared-bin` == `cloudflared`. Thus, they should be merged.