### PR TITLE
dhcping: add verignore

### DIFF
--- a/900.version-fixes/d.yaml
+++ b/900.version-fixes/d.yaml
@@ -71,6 +71,8 @@
 - { name: dhcp,                        verpat: "[0-9]+(\\.[0-9]+){3}",                     incorrect: true }
 - { name: dhcp,                                                      ruleset: [openbsd,openmamba], untrusted: true } # accused of fake 4.4.2.1
 - { name: dhcp,                                                                            p_is_patch: true }
+- { name: dhcping,                     verpat: ".*_.*",              ruleset: slackbuilds, incorrect: true }
+- { name: dhcping,                                                   ruleset: slackbuilds, untrusted: true } # accussed of fake 1.2_6
 - { name: dhewm3,                      ver: "1.4.2",                 ruleset: [ fedora ],  ignore: true } # no such version (rpmfusion)
 - { name: dhewm3,                      ver: "1.5.1",                 ruleset: [haikuports,fedora], incorrect: true } # 1.5.1 pre1
 - { name: dhewm3,                                                    ruleset: [haikuports,fedora], untrusted: true } # accused of fake 1.5.1


### PR DESCRIPTION
Modifying versions from https://repology.org/project/dhcping/versions

- dhcping is a tool which checks whether a dhcp-server is running, hosted at https://www.mavetju.org/unix/general.php
- The current stable release for `dhcping` is `1.2`, as reported by the aforementioned upstream.
- SlackBuilds reports version `1.2_6`. However, the aforementioned upstream and homepage don't reflect that.

`dhcping`: `1.2_6` =/= `1.2`. Thus, `1.2_6` is a fake version and should not be considered as latest.