### PR TITLE
google-chrome: update devel rule to 154

### DIFF
--- a/900.version-fixes/g.yaml
+++ b/900.version-fixes/g.yaml
@@ -302,7 +302,7 @@
 - { name: goocanvasmm,                 verpat: "[0-9]+\\.[0-9]*[13579]\\..*",              devel: true }
 - { name: google-authenticator,        verpat: "20[0-9]{6}.*",                             incorrect: true }
 - { name: google-authenticator-libpam, verpat: "20[0-9]{6}.*",                             incorrect: true }
-- { name: google-chrome,               verge: "153",                                       devel: true, maintenance: true } # latest stable mentioned at https://chromereleases.googleblog.com/, needs update every major stable promotion
+- { name: google-chrome,               verge: "154",                                       devel: true, maintenance: true } # latest stable mentioned at https://chromereleases.googleblog.com/, needs update every major stable promotion
 - { name: googlecl,                    ver: "0.9.15.1",              ruleset: freebsd,     incorrect: true }
 - { name: googlecl,                                                  ruleset: freebsd,     untrusted: true }
 - { name: goom,                        verpat: "2004(.*)",                                 setver: "2k4$1" }


### PR DESCRIPTION
Chrome 153 is now stable (promoted September 8, 2026 as per https://chromereleases.googleblog.com/2026/09/stable-channel-update-for-desktop_0808145027.html). This rule marks version 154 and higher (currently 154 Beta / 155 Dev) as development versions.

This ensures Repology correctly identifies 153 as the latest stable release and more accurately calculates package freshness across repositories.